### PR TITLE
Avoid adding duplicate libraries and update the SPRTA integration according to Minh's comments

### DIFF
--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -3250,6 +3250,33 @@ void startTreeReconstruction(Params &params, IQTree* &iqtree, ModelCheckpoint &m
     runModelFinder(params, *iqtree, model_info, best_subst_name, best_rate_name, nest_network);
     
     optimiseQMixModel(params, iqtree, model_info);
+    
+    // if users want to perform tree dating (with mcmc)
+    // and if ModelFinder was run, the traversal starting node was incidently deleted (after copyTree and restoreCheckpoint)
+    // we have to delete tree nodes to force IQ-TREE to re-read the tree from the treefile
+    if (params.dating_method == "mcmctree" && params.dating_mf)
+    {
+        // if it's a supertree, delete all tree members
+        if (iqtree->isSuperTree())
+        {
+            PhyloSuperTree* stree = (PhyloSuperTree*) iqtree;
+            // delete member trees one by one
+            for (PhyloSuperTree::iterator it = stree->begin(); it != stree->end(); it++)
+            {
+                if ((*it)->root)
+                {
+                    (*it)->freeNode();
+                    (*it)->root = NULL;
+                }
+            }
+        }
+        // delete the tree itself
+        if (iqtree->root)
+        {
+            iqtree->freeNode();
+            iqtree->root = NULL;
+        }
+    }
 }
         
 /**
@@ -5104,11 +5131,6 @@ void runPhyloAnalysis(Params &params, Checkpoint *checkpoint, IQTree *&tree, Ali
         alignment = NULL; // from now on use tree->aln instead
 
         startTreeReconstruction(params, tree, *model_info);
-        if (params.dating_method == "mcmctree" && params.dating_mf)
-        {
-            cout << "Initializing rooted tree again from input tree file for MCMCtree dating ..." << endl;
-            tree->computeInitialTree(params.SSE);
-        }
         // call main tree reconstruction
         if (params.num_runs == 1) {
             runTreeReconstruction(params, tree);

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -5213,6 +5213,7 @@ bool runCMaple(Params &params)
     {
         // record the start time
         auto start = getRealTime();
+        auto start_cpu = getCPUTime();
 
         // Dummy variables
         std::string aln_path(params.aln_file);
@@ -5289,6 +5290,15 @@ bool runCMaple(Params &params)
             // Initialize a Tree
             const std::string input_treefile(params.user_file ? params.user_file : "");
             cmaple::Tree tree(&aln, &model, input_treefile, (params.fixed_branch_length == BRLEN_FIX), cmaple::ParamsBuilder().build());
+            
+            // transfer SPRTA options if any
+            if (params.compute_SPRTA)
+            {
+                tree.params->compute_SPRTA = params.compute_SPRTA;
+                tree.params->compute_SPRTA_zero_length_branches = params.SPRTA_zero_branches;
+                tree.params->print_SPRTA_less_info_seqs = params.SPRTA_zero_branches;
+                tree.params->output_alternative_spr = params.out_alter_spr;
+            }
 
             // Infer a phylogenetic tree
             const cmaple::Tree::TreeSearchType tree_search_type = cmaple::Tree::parseTreeSearchType(params.tree_search_type_str);
@@ -5325,6 +5335,22 @@ bool runCMaple(Params &params)
             ofstream out = ofstream(output_treefile);
             out << tree.exportNewick(tree_format);
             out.close();
+            
+            // Write tree file in NEXUS format (if computing SPRTA)
+            if (params.compute_SPRTA)
+            {
+                ofstream out = ofstream(output_treefile + ".nexus");
+                out << tree.exportNexus(tree_format);
+                out.close();
+            }
+
+            // export a TSV file if SPRTA is computed and we output alternative SPRs
+            if (params.compute_SPRTA && params.out_alter_spr)
+            {
+                ofstream out = ofstream(output_treefile + ".tsv");
+                out << tree.exportTSV();
+                out.close();
+            }
 
             // Show model parameters
             if (cmaple::verbose_mode > cmaple::VB_QUIET)
@@ -5340,14 +5366,20 @@ bool runCMaple(Params &params)
             // Show information about output files
             std::cout << "Analysis results written to:" << std::endl;
             std::cout << "Maximum-likelihood tree:       " << output_treefile << std::endl;
-            /*if (params.aLRT_replicates)
-                std::cout << "Tree with aLRT-SH values:      " << prefix + ".aLRT_SH.treefile" << std::endl;*/
+            if (params.compute_SPRTA)
+                std::cout << "Tree in NEXUS format:      " << output_treefile + ".nexus" << std::endl;
+            if (params.compute_SPRTA && params.out_alter_spr)
+                std::cout << "Meta data in TSV format:   " << output_treefile + ".tsv" << std::endl;
             std::cout << "Screen log file:               " << prefix + ".log" << std::endl << std::endl;
 
             // show runtime
             auto end = getRealTime();
-            if (cmaple::verbose_mode > cmaple::VB_QUIET)
-                cout << "CMAPLE Runtime: " << end - start << "s" << endl;
+            auto end_cpu = getCPUTime();
+            cout << "Total CPU time used: " << fixed << end_cpu - start_cpu << " sec (" <<
+                convert_time(end_cpu-start_cpu) << ")" << endl;
+            cout << "Total wall-clock time used: " << fixed << end - start << " sec (" <<
+                convert_time(end-start) << ")" << endl;
+            cout << endl;
         }
     }
     catch (std::invalid_argument e)

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -5178,6 +5178,15 @@ void runPhyloAnalysis(Params &params, Checkpoint *checkpoint, IQTree *&tree, Ali
 
 void runPhyloAnalysis(Params &params, Checkpoint *checkpoint) {
     bool runCMapleAlg = false;
+    // if users want to compute SPRTA, enforce using CMAPLE
+    if (params.compute_SPRTA)
+    {
+        if (params.inference_alg != ALG_CMAPLE)
+        {
+            params.inference_alg = ALG_CMAPLE;
+            outWarning("Enforce using CMAPLE tree search algorithm for computing SPRTA.");
+        }
+    }
     // check and run CMaple algorithm (if users want to do so)
     if (params.inference_alg != ALG_IQ_TREE)
         runCMapleAlg = runCMaple(params);

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -5339,7 +5339,7 @@ bool runCMaple(Params &params)
             // Write tree file in NEXUS format (if computing SPRTA)
             if (params.compute_SPRTA)
             {
-                ofstream out = ofstream(output_treefile + ".nexus");
+                ofstream out = ofstream(output_treefile + ".nex");
                 out << tree.exportNexus(tree_format);
                 out.close();
             }
@@ -5367,7 +5367,7 @@ bool runCMaple(Params &params)
             std::cout << "Analysis results written to:" << std::endl;
             std::cout << "Maximum-likelihood tree:       " << output_treefile << std::endl;
             if (params.compute_SPRTA)
-                std::cout << "Tree in NEXUS format:      " << output_treefile + ".nexus" << std::endl;
+                std::cout << "Tree in NEXUS format:      " << output_treefile + ".nex" << std::endl;
             if (params.compute_SPRTA && params.out_alter_spr)
                 std::cout << "Meta data in TSV format:   " << output_treefile + ".tsv" << std::endl;
             std::cout << "Screen log file:               " << prefix + ".log" << std::endl << std::endl;

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -5323,6 +5323,10 @@ bool runCMaple(Params &params)
                 // if users input a tree -> depend on the setting in params (false ~ don't allow replacing (by default)
                 if (input_treefile.length())
                     allow_replacing_ML_tree = params.allow_replace_input_tree;
+                
+                // if SPRTA was computed, don't allow changing tree topology
+                if (params.compute_SPRTA)
+                    allow_replacing_ML_tree = false;
 
                 tree.computeBranchSupport(params.num_threads, params.aLRT_replicates, 0.1, allow_replacing_ML_tree, out_stream);
 

--- a/main/phylotesting.cpp
+++ b/main/phylotesting.cpp
@@ -1318,6 +1318,10 @@ void runModelFinder(Params &params, IQTree &iqtree, ModelCheckpoint &model_info,
     // Model already specifed, nothing to do here
     if (!empty_model_found && params.model_name.substr(0, 4) != "TEST" && params.model_name.substr(0, 2) != "MF")
         return;
+    
+    // update the flag: ModelFinder is run
+    params.dating_mf = true;
+    
     // if (MPIHelper::getInstance().getNumProcesses() > 1)
     //    outError("Please use only 1 MPI process! We are currently working on the MPI parallelization of model selection.");
     // TODO: check if necessary

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -6123,18 +6123,6 @@ void usage(char* argv[]) {
     //	cout << "  -rep <times>        Repeat algorithm a number of times." << endl;
     //	cout << "  -noout              Print no output file." << endl;
     cout << endl;
-    cout << "OPTIONS FOR GENOMIC EPIDEMIOLOGICAL ANALYSES:" << endl;
-    cout << "  --pathogen           Apply CMAPLE tree search algorithm if sequence" << endl;
-    cout << "                       divergence is low, otherwise, apply IQ-TREE algorithm." << endl;
-    cout << "  --pathogen-force     Apply CMAPLE tree search algorithm regardless" << endl;
-    cout << "                       of sequence divergence." << endl;
-    cout << "  --alrt <num_rep>     Specify number of replicates to compute SH-aLRT." << endl;
-    cout << "  --sprta              Compute SPRTA (DeMaio et al., 2024) branch supports." << endl;
-    cout << "  --sprta-zero-branch  Compute SPRTA supports for zero-length branches." << endl;
-    cout << "  --sprta-other-places Output alternative SPRs and their SPRTA supports." << endl;
-    cout << "  -T <num_thread>      Specify number of threads used for computing" << endl;
-    cout << "                       branch supports (SH-aLRT or SPRTA)." << endl;
-    cout << endl;
     //cout << "HIDDEN OPTIONS: see the source code file pda.cpp::parseArg()" << endl;
 
     exit(0);

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -6128,6 +6128,12 @@ void usage(char* argv[]) {
     cout << "                       divergence is low, otherwise, apply IQ-TREE algorithm." << endl;
     cout << "  --pathogen-force     Apply CMAPLE tree search algorithm regardless" << endl;
     cout << "                       of sequence divergence." << endl;
+    cout << "  --alrt <num_rep>     Specify number of replicates to compute SH-aLRT." << endl;
+    cout << "  --sprta              Compute SPRTA (DeMaio et al., 2024) branch supports." << endl;
+    cout << "  --zero-branch-supp   Compute SPRTA supports for zero-length branches." << endl;
+    cout << "  --out-alter-spr      Output alternative SPRs and their SPRTA supports." << endl;
+    cout << "  -T <num_thread>      Specify number of threads used for computing" << endl;
+    cout << "                       branch supports (SH-aLRT or SPRTA)." << endl;
     cout << endl;
     //cout << "HIDDEN OPTIONS: see the source code file pda.cpp::parseArg()" << endl;
 
@@ -6450,6 +6456,12 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "                       divergence is low, otherwise, apply IQ-TREE algorithm." << endl
     << "  --pathogen-force     Apply CMAPLE tree search algorithm regardless" << endl
     << "                       of sequence divergence." << endl
+    << "  --alrt <num_rep>     Specify number of replicates to compute SH-aLRT." << endl
+    << "  --sprta              Compute SPRTA (DeMaio et al., 2024) branch supports." << endl
+    << "  --zero-branch-supp   Compute SPRTA supports for zero-length branches." << endl
+    << "  --out-alter-spr      Output alternative SPRs and their SPRTA supports." << endl
+    << "  -T <num_thread>      Specify number of threads used for computing" << endl
+    << "                       branch supports (SH-aLRT or SPRTA)." << endl
 
 
     

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -3217,14 +3217,14 @@ void parseArg(int argc, char *argv[], Params &params) {
 
               continue;
             }
-            if (strcmp(argv[cnt], "--zero-branch-supp") == 0 ||
-                strcmp(argv[cnt], "-zero-branch-supp") == 0) {
+            if (strcmp(argv[cnt], "--sprta-zero-branch") == 0 ||
+                strcmp(argv[cnt], "-sprta-zero-branch") == 0) {
               params.SPRTA_zero_branches = true;
 
               continue;
             }
-            if (strcmp(argv[cnt], "--out-alter-spr") == 0 ||
-                strcmp(argv[cnt], "-out-alter-spr") == 0) {
+            if (strcmp(argv[cnt], "--sprta-other-places") == 0 ||
+                strcmp(argv[cnt], "-sprta-other-places") == 0) {
               params.out_alter_spr = true;
 
               continue;
@@ -6130,8 +6130,8 @@ void usage(char* argv[]) {
     cout << "                       of sequence divergence." << endl;
     cout << "  --alrt <num_rep>     Specify number of replicates to compute SH-aLRT." << endl;
     cout << "  --sprta              Compute SPRTA (DeMaio et al., 2024) branch supports." << endl;
-    cout << "  --zero-branch-supp   Compute SPRTA supports for zero-length branches." << endl;
-    cout << "  --out-alter-spr      Output alternative SPRs and their SPRTA supports." << endl;
+    cout << "  --sprta-zero-branch  Compute SPRTA supports for zero-length branches." << endl;
+    cout << "  --sprta-other-places Output alternative SPRs and their SPRTA supports." << endl;
     cout << "  -T <num_thread>      Specify number of threads used for computing" << endl;
     cout << "                       branch supports (SH-aLRT or SPRTA)." << endl;
     cout << endl;
@@ -6458,8 +6458,8 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "                       of sequence divergence." << endl
     << "  --alrt <num_rep>     Specify number of replicates to compute SH-aLRT." << endl
     << "  --sprta              Compute SPRTA (DeMaio et al., 2024) branch supports." << endl
-    << "  --zero-branch-supp   Compute SPRTA supports for zero-length branches." << endl
-    << "  --out-alter-spr      Output alternative SPRs and their SPRTA supports." << endl
+    << "  --sprta-zero-branch  Compute SPRTA supports for zero-length branches." << endl
+    << "  --sprta-other-places Output alternative SPRs and their SPRTA supports." << endl
     << "  -T <num_thread>      Specify number of threads used for computing" << endl
     << "                       branch supports (SH-aLRT or SPRTA)." << endl
 

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -1608,6 +1608,11 @@ void parseArg(int argc, char *argv[], Params &params) {
     params.include_pre_mutations = false;
     params.mutation_file = "";
     params.site_starting_index = 0;
+    
+    // ----------- SPRTA ----------
+    params.compute_SPRTA = false;
+    params.SPRTA_zero_branches = false;
+    params.out_alter_spr = false;
 
     // store original params
     for (cnt = 1; cnt < argc; cnt++) {
@@ -3205,6 +3210,24 @@ void parseArg(int argc, char *argv[], Params &params) {
             if (strcmp(argv[cnt], "-pathogen-force") == 0 || strcmp(argv[cnt], "--pathogen-force") == 0) {
                 params.inference_alg = ALG_CMAPLE;
                 continue;
+            }
+            if (strcmp(argv[cnt], "--sprta") == 0 ||
+                strcmp(argv[cnt], "-sprta") == 0) {
+              params.compute_SPRTA = true;
+
+              continue;
+            }
+            if (strcmp(argv[cnt], "--zero-branch-supp") == 0 ||
+                strcmp(argv[cnt], "-zero-branch-supp") == 0) {
+              params.SPRTA_zero_branches = true;
+
+              continue;
+            }
+            if (strcmp(argv[cnt], "--out-alter-spr") == 0 ||
+                strcmp(argv[cnt], "-out-alter-spr") == 0) {
+              params.out_alter_spr = true;
+
+              continue;
             }
             if (strcmp(argv[cnt], "--out-csv") == 0) {
                 params.output_format = FORMAT_CSV;

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -2809,6 +2809,24 @@ public:
      * TRUE to make the processes of outputting->re-inputting a tree consistent
      */
     bool make_consistent;
+    
+    /**
+     * @private
+     * TRUE to compute the SPRTA branch supports
+     */
+    bool compute_SPRTA;
+
+    /**
+     * @private
+     * TRUE to compute the SPRTA for zero-length branches
+     */
+    bool SPRTA_zero_branches;
+
+    /**
+     * @private
+     * TRUE to output the alternative SPRs with their supports in the tree
+     */
+    bool out_alter_spr;
 
     /**
     *  Mutation file that specifies pre-defined mutations occurs at nodes


### PR DESCRIPTION
1. Avoid adding duplicate libraries `ld: warning: ignoring duplicate libraries: '-lomp', 'alignment/libcmaple_alignment.a', 'utils/libcmaple_utils.a'`.
2. Update the SPRTA integration according to Minh's comments:
- change --zero-branch-supp to --sprta-zero-branch or something simpler
- change --out-alter-spr to --sprta-other-places
- change .nexus to .nex
- make sure that the bracket notations in nexus file follow other features in IQ-TREE such as concordance factor.
remove all help usages in usage() function, you only need to keep them in usage_iqtree
3. Fix issue [#435 in iqtree2 ](https://github.com/iqtree/iqtree2/issues/435)