### PR TITLE
Extend MixtureFinder to codon, binary, multistate, and amino acid data

### DIFF
--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -48,6 +48,7 @@
 //#include "modeltest_wrapper.h"
 #include "model/modelprotein.h"
 #include "model/modelbin.h"
+#include "model/modelmultistate.h"
 #include "model/modelcodon.h"
 #include "utils/stoprule.h"
 
@@ -249,6 +250,7 @@ void reportAlignment(ofstream &out, Alignment &alignment, int nremoved_seqs) {
             << alignment.getNSite() << " ";
     switch (alignment.seq_type) {
     case SEQ_BINARY: out << "binary"; break;
+    case SEQ_MULTISTATE: out << "multistate"; break;
     case SEQ_DNA: out << "nucleotide"; break;
     case SEQ_PROTEIN: out << "amino-acid"; break;
     case SEQ_CODON: out << "codon"; break;
@@ -2064,7 +2066,7 @@ void exportAliSimCMD(Params &params, IQTree &tree, ostream &out)
 {
     // make sure this method will not make IQTREE crashed
     if (!(params.aln_file || params.partition_file) || !params.out_prefix || !tree.aln || !tree.getModel()
-        || !(tree.aln->seq_type == SEQ_DNA || tree.aln->seq_type == SEQ_CODON || tree.aln->seq_type == SEQ_PROTEIN || tree.aln->seq_type == SEQ_BINARY || tree.aln->seq_type == SEQ_MORPH)
+        || !(tree.aln->seq_type == SEQ_DNA || tree.aln->seq_type == SEQ_CODON || tree.aln->seq_type == SEQ_PROTEIN || tree.aln->seq_type == SEQ_BINARY || tree.aln->seq_type == SEQ_MULTISTATE || tree.aln->seq_type == SEQ_MORPH)
         || tree.isTreeMix())
         return;
     
@@ -2076,7 +2078,7 @@ void exportAliSimCMD(Params &params, IQTree &tree, ostream &out)
     // skip unsupported models
     if (tree.getModel()->isMixture() || tree.getRate()->isHeterotachy() || tree.getModel()->isLieMarkov() || tree.aln->seq_type == SEQ_CODON)
     {
-        out << "Currently, we only support exporting AliSim commands automatically from the analysis for common models of DNA, Protein, Binary, and Morphological data. To simulate data from other models (mixture, lie-markov, etc), please refer to the User Manual of AliSim. Thanks!" << endl << endl;
+        out << "Currently, we only support exporting AliSim commands automatically from the analysis for common models of DNA, Protein, Binary, Multistate, and Morphological data. To simulate data from other models (mixture, lie-markov, etc), please refer to the User Manual of AliSim. Thanks!" << endl << endl;
         out << more_info << endl << endl;
         return;
     }

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(model
 modelmarkov.cpp modelmarkov.h
 modelbin.cpp modelbin.h
+modelmultistate.cpp modelmultistate.h
 modeldna.cpp modeldna.h
 modeldnaerror.cpp modeldnaerror.h
 modelfactory.cpp modelfactory.h

--- a/model/modelfactory.cpp
+++ b/model/modelfactory.cpp
@@ -26,6 +26,7 @@
 #include "modeldna.h"
 #include "modelprotein.h"
 #include "modelbin.h"
+#include "modelmultistate.h"
 #include "modelcodon.h"
 #include "modelmorphology.h"
 #include "modelpomo.h"
@@ -167,6 +168,7 @@ ModelFactory::ModelFactory(Params &params, string &model_name, PhyloTree *tree, 
         if (tree->aln->seq_type == SEQ_DNA) model_str = "HKY";
         else if (tree->aln->seq_type == SEQ_PROTEIN) model_str = "LG";
         else if (tree->aln->seq_type == SEQ_BINARY) model_str = "GTR2";
+        else if (tree->aln->seq_type == SEQ_MULTISTATE) model_str = "GTRX";
         else if (tree->aln->seq_type == SEQ_CODON) model_str = "GY";
         else if (tree->aln->seq_type == SEQ_MORPH) model_str = "MK";
         else if (tree->aln->seq_type == SEQ_POMO) model_str = "HKY+P";
@@ -436,6 +438,7 @@ ModelFactory::ModelFactory(Params &params, string &model_name, PhyloTree *tree, 
     if (model_str.substr(0, 3) != "MIX" && freq_type == FREQ_UNKNOWN) {
         switch (tree->aln->seq_type) {
         case SEQ_BINARY: freq_type = FREQ_ESTIMATE; break; // default for binary: optimized frequencies
+        case SEQ_MULTISTATE: freq_type = FREQ_ESTIMATE; break; // default for multistate data: optimized frequencies
         case SEQ_PROTEIN: break; // let ModelProtein decide by itself
         case SEQ_MORPH: freq_type = FREQ_EQUAL; break;
         case SEQ_CODON: freq_type = FREQ_UNKNOWN; break;

--- a/model/modelmixture.cpp
+++ b/model/modelmixture.cpp
@@ -10,6 +10,7 @@
 #include "modeldnaerror.h"
 #include "modelprotein.h"
 #include "modelbin.h"
+#include "modelmultistate.h"
 #include "modelcodon.h"
 #include "modelmorphology.h"
 #include "modelset.h"
@@ -1138,6 +1139,7 @@ ModelSubst* createModel(string model_str, ModelsBlock *models_block,
 	if ((model_str == "JC" && tree->aln->seq_type == SEQ_DNA) ||
 		(model_str == "POISSON" && tree->aln->seq_type == SEQ_PROTEIN) ||
 		(model_str == "JC2" && tree->aln->seq_type == SEQ_BINARY) ||
+    (model_str == "MK" && tree->aln->seq_type == SEQ_MULTISTATE) ||
 		(model_str == "JCC" && tree->aln->seq_type == SEQ_CODON) ||
 		(model_str == "MK" && tree->aln->seq_type == SEQ_MORPH))
 	{
@@ -1153,6 +1155,7 @@ ModelSubst* createModel(string model_str, ModelsBlock *models_block,
             cout << "PoMo mixture model for Gamma rate heterogeneity." << endl;
 //	else if ((model_str == "GTR" && tree->aln->seq_type == SEQ_DNA) ||
 //             (model_str == "GTR2" && tree->aln->seq_type == SEQ_BINARY) ||
+//             ((model_str == "GTR" || model_str == "GTRX") && model_str ==  SEQ_MULTISTATE) ||
 //             (model_str == "GTR20" && tree->aln->seq_type == SEQ_PROTEIN)) {
 //		model = new ModelGTR(tree, count_rates);
 //		if (freq_params != "")
@@ -1165,7 +1168,9 @@ ModelSubst* createModel(string model_str, ModelsBlock *models_block,
 	        model = ModelMarkov::getModelByName(model_str, tree, model_params, freq_type, freq_params);
 	} else if (tree->aln->seq_type == SEQ_BINARY) {
 		model = new ModelBIN(model_str.c_str(), model_params, freq_type, freq_params, tree);
-	} else if (tree->aln->seq_type == SEQ_DNA) {
+  } else if (tree->aln->seq_type == SEQ_MULTISTATE) {
+    model = new ModelMultistate(model_str.c_str(), model_params, freq_type, freq_params, tree);
+  } else if (tree->aln->seq_type == SEQ_DNA) {
         if (seqerr.empty())
             model = new ModelDNA(model_str.c_str(), model_params, freq_type, freq_params, tree);
         else

--- a/model/modelmultistate.cpp
+++ b/model/modelmultistate.cpp
@@ -1,0 +1,174 @@
+/*
+ * modelmultistate.cpp
+ *
+ *  Created on: Apr 6, 2025
+ *      Author: Hiroaki Sato
+ *      Original author: minh
+ */
+
+#include "modelmultistate.h"
+
+ModelMultistate::ModelMultistate(const char *model_name, string model_params, StateFreqType freq, string freq_params, PhyloTree *tree)
+: ModelMarkov(tree)
+{
+	init(model_name, model_params, freq, freq_params);
+}
+
+void ModelMultistate::init(const char *model_name, string model_params, StateFreqType freq, string freq_params)
+{
+	name = model_name;
+	full_name = model_name;
+	if (name == "MK") {
+		// all were initialized
+        num_params = 0;
+	} else if (name == "ORDERED") {
+		int i, j, k = 0;
+		// only allow for substitution from state i to state i+1 and back.
+		for (i = 0; i < num_states-1; i++) {
+			rates[k++] = 1.0;
+			for (j = i+2; j < num_states; j++, k++)
+				rates[k] = 0.0;
+		}
+        num_params = 0;
+    } else if (name == "GTR" || name == "GTRX") {
+        outWarning("GTRX multistate model will estimate " + convertIntToString(getNumRateEntries()-1) + " substitution rates that might be overfitting!");
+        outWarning("Please only use GTRX with very large data and always test for model fit!");
+        name = "GTRX";
+	} else {
+		// if name does not match, read the user-defined model
+		readParameters(model_name);
+        num_params = 0;
+        freq = FREQ_USER_DEFINED;
+	}
+    
+    // parse user-specified state frequencies (if any)
+    if (freq_params != "")
+    {
+        freq_type = FREQ_USER_DEFINED;
+        readStateFreq(freq_params);
+    }
+    
+	ModelMarkov::init(freq);
+}
+
+void ModelMultistate::readRates(istream &in) noexcept(false) {
+	int nrates = getNumRateEntries();
+	int row = 1, col = 0;
+	// since states for protein is stored in lower-triangle, special treatment is needed
+	for (int i = 0; i < nrates; i++, col++) {
+		if (col == row) {
+			row++; col = 0;
+		}
+		// switch col and row
+		int id = col*(2*num_states-col-1)/2 + (row-col-1);
+		if (id >= nrates) {
+			cout << row << " " << col << endl;
+		}
+		assert(id < nrates && id >= 0); // make sure that the conversion is correct
+        
+        string tmp_value;
+        in >> tmp_value;
+        if (tmp_value.length() == 0)
+            throw name+string(": Rate entries could not be read");
+        rates[id] = convert_double_with_distribution(tmp_value.c_str(), true);
+        
+		if (rates[id] < 0.0)
+			throw "Negative rates found";
+	}
+}
+
+int ModelMultistate::getNDim() {
+    int ndim = num_params;
+    if (freq_type == FREQ_ESTIMATE)
+        ndim += num_states-1;
+    return ndim;
+}
+
+ModelMultistate::~ModelMultistate() {
+}
+
+void ModelMultistate::startCheckpoint() {
+    checkpoint->startStruct("ModelMorph");
+}
+
+void ModelMultistate::saveCheckpoint() {
+    startCheckpoint();
+    if (num_params > 0)
+        CKP_ARRAY_SAVE(getNumRateEntries(), rates);
+    endCheckpoint();
+    ModelMarkov::saveCheckpoint();
+}
+
+void ModelMultistate::restoreCheckpoint() {
+    ModelMarkov::restoreCheckpoint();
+    startCheckpoint();
+    if (num_params > 0)
+        CKP_ARRAY_RESTORE(getNumRateEntries(), rates);
+    endCheckpoint();
+    decomposeRateMatrix();
+    if (phylo_tree)
+        phylo_tree->clearAllPartialLH();
+}
+
+/**
+ * @return model name
+ */
+string ModelMultistate::getName() {
+    size_t pos_plus = name.find('+');
+    if (pos_plus != string::npos) {
+        return name;
+    } else {
+        return ModelMarkov::getName();
+    }
+}
+
+string ModelMultistate::getNameParams(bool show_fixed_params) {
+    if (num_params == 0) return name;
+    ostringstream retname;
+    size_t pos_plus = name.find('+');
+    if (pos_plus != string::npos) {
+        retname << name.substr(0, pos_plus) << '{';
+    } else {
+        retname << name << '{';
+    }
+    int nrates = getNumRateEntries();
+    for (int i = 0; i < nrates; i++) {
+        if (i>0) retname << ',';
+        retname << rates[i];
+    }
+    retname << '}';
+    if (pos_plus != string::npos) {
+        retname << name.substr(pos_plus);
+    } else {
+        getNameParamsFreq(retname);
+    }
+    return retname.str();
+}
+
+void ModelMultistate::writeParameters(ostream &out) {
+    int i;
+    if (freq_type == FREQ_ESTIMATE) {
+        for (i = 0; i < num_states; i++)
+            out << "\t" << state_freq[i];
+    }
+    if (num_params == 0) return;
+    int nrateout = getNumRateEntries() - 1;
+    for (i = 0; i < nrateout; i++)
+        out << "\t" << rates[i];
+}
+
+void ModelMultistate::writeInfo(ostream &out) {
+    if (num_params > 0) {
+        out << "Rate parameters:";
+        int nrate = getNumRateEntries();
+        for (int i = 0; i < nrate; i++)
+            out << " " << rates[i];
+        out << endl;
+    }
+    if (freq_type != FREQ_EQUAL) {
+        out << "State frequencies:";
+        for (int i = 0; i < num_states; i++)
+            out << " " << state_freq[i];
+        out << endl;
+    }
+}

--- a/model/modelmultistate.h
+++ b/model/modelmultistate.h
@@ -1,0 +1,83 @@
+/*
+ * modelmultistate.h
+ *
+ *  Created on: Apr 6, 2025
+ *      Author: Hiroaki Sato
+ *      Original author: minh
+ */
+
+#ifndef MODELMULTISTATE_H_
+#define MODELMULTISTATE_H_
+
+#include "modelmarkov.h"
+
+class ModelMultistate: public ModelMarkov {
+public:
+	/**
+		constructor
+		@param model_name model name, e.g., JC, HKY.
+		@param freq state frequency type
+		@param tree associated phylogenetic tree
+	*/
+	ModelMultistate(const char *model_name, string model_params, StateFreqType freq, string freq_params, PhyloTree *tree);
+
+
+	/**
+		initialization, called automatically by the constructor, no need to call it
+		@param model_name model name, e.g., JC, HKY.
+		@param freq state frequency type
+	*/
+	virtual void init(const char *model_name, string model_params, StateFreqType freq, string freq_params);
+
+    /**
+     return the number of dimensions
+     */
+    virtual int getNDim();
+
+    /**
+        start structure for checkpointing
+    */
+    virtual void startCheckpoint();
+    
+    /**
+     save object into the checkpoint
+     */
+    virtual void saveCheckpoint();
+    
+    /**
+     restore object from the checkpoint
+     */
+    virtual void restoreCheckpoint();
+
+    /**
+     * @return model name
+     */
+    virtual string getName();
+
+    /**
+     * @return model name with parameters in form of e.g. GTR{a,b,c,d,e,f}
+     */
+    virtual string getNameParams(bool show_fixed_params = false);
+
+    /**
+     write information
+     @param out output stream
+     */
+    virtual void writeInfo(ostream &out);
+
+    /**
+     write parameters, used with modeltest
+     @param out output stream
+     */
+    virtual void writeParameters(ostream &out);
+
+	/**
+		read the rates from an input stream. it will throw error messages if failed
+		@param in input stream
+	*/
+    virtual void readRates(istream &in) noexcept(false);
+
+		virtual ~ModelMultistate();
+};
+
+#endif /* MODELMUTISTATE_H_ */


### PR DESCRIPTION
Dear IQ-TREE Developers,

**This pull request extends MixtureFinder ([Ren et al., 2024](https://doi.org/10.1093/molbev/msae264)), which currently works only on DNA data, to codon, binary, multistate, and amino acid data.**

For multistate and amino acid data, the frequency parameters `FQ` and `FO` are tested by default, and for codon data, the frequency parameters `FQ`, `F`, `F1X4`, and `F3X4` are tested by default. As I have never done any phylogenetic analyses of codon or amino acid data in my actual research, I apologize if I am doing something wrong.

I have tested it with DNA, codon, binary, multistate and amino acid data to see if it works properly, and it seems to work fine. The test data can be found at [HS6986/iqtree3ForkTests](https://github.com/HS6986/iqtree3ForkTests).

Since I am completely unfamiliar with C++ and have little understanding of the IQ-TREE implementation, I believe that perhaps this PR might contain bugs and there are many improvements that could be made. Therefore, it almost certainly needs extensive code review by you, the IQ-TREE developers. If you would like to get access to my repository for editing, please feel free to ask.

This is almost my first PR, so please feel free to let me know if I am doing something wrong.

Thank you very much for your time and support.