### PR TITLE
Fix a bug where +FU are not allowed in mixture models

### DIFF
--- a/model/modelmixture.cpp
+++ b/model/modelmixture.cpp
@@ -1403,6 +1403,8 @@ void ModelMixture::initMixture(string orig_model_name, string model_name, string
                     } else {
                         outError("The user defined frequency model is incorrect");
                     }
+                } else if (fstr == "+FU" || fstr == "+Fu") {
+                    model_freq = FREQ_USER_DEFINED;
                 } else if (fstr == "+FO" || fstr == "+Fo") {
                     model_freq = FREQ_ESTIMATE;
                 } else if (fstr == "+FQ" || fstr == "+Fq") {


### PR DESCRIPTION
Dear IQ-TREE Developers,

This PR fixes a bug that +FU are not allowed in mixture models. This bug has been fixed in the pull request on extending MixtureFinder (https://github.com/iqtree/iqtree3/pull/11), but this PR has not yet been approved. As such, I am presenting this PR so that the correction will be published as soon as possible.