### PR TITLE
Fix a bug where the state frequencies of morphological (multistate) models are not printed in the .iqtree file

### DIFF
--- a/model/modelmorphology.cpp
+++ b/model/modelmorphology.cpp
@@ -122,20 +122,22 @@ string ModelMorphology::getName() {
 }
 
 string ModelMorphology::getNameParams(bool show_fixed_params) {
-    if (num_params == 0) return name;
     ostringstream retname;
     size_t pos_plus = name.find('+');
     if (pos_plus != string::npos) {
-        retname << name.substr(0, pos_plus) << '{';
+        retname << name.substr(0, pos_plus);
     } else {
-        retname << name << '{';
+        retname << name;
     }
-    int nrates = getNumRateEntries();
-    for (int i = 0; i < nrates; i++) {
-        if (i>0) retname << ',';
-        retname << rates[i];
+    if (num_params > 0 || show_fixed_params) {
+        retname << '{';
+        int nrates = getNumRateEntries();
+        for (int i = 0; i < nrates; i++) {
+            if (i > 0) retname << ',';
+            retname << rates[i];
+        }
+        retname << '}';
     }
-    retname << '}';
     if (pos_plus != string::npos) {
         retname << name.substr(pos_plus);
     } else {


### PR DESCRIPTION
Dear IQ-TREE Developers,

This PR fixes a bug that the state frequencies of morphological (multistate) models are not printed in the .iqtree file. This bug has been fixed in the pull request on extending MixtureFinder (https://github.com/iqtree/iqtree3/pull/11), but this PR has not yet been approved. As such, I am presenting this PR so that the correction will be published as soon as possible. The bulk of the code was written by [StefanFlaumberg](https://github.com/StefanFlaumberg).