### PR TITLE
Fixed bug #56 remove redundant ",," when outputting the best_model.nex

### DIFF
--- a/tree/phylosupertree.cpp
+++ b/tree/phylosupertree.cpp
@@ -1542,8 +1542,7 @@ void PhyloSuperTree::printBestPartitionParams(const char *filename) {
             if (!saln->partitions[part]->aln_file.empty()) out << saln->partitions[part]->aln_file << ": ";
             /*if (saln->partitions[part]->seq_type == SEQ_CODON)
                 out << "CODON, ";*/
-            if (!saln->partitions[part]->sequence_type.empty())
-                out << saln->partitions[part]->sequence_type << ",";
+            out << saln->partitions[part]->sequence_type;
             string pos = saln->partitions[part]->position_spec;
             replace(pos.begin(), pos.end(), ',' , ' ');
             if (!saln->partitions[part]->sequence_type.empty() && !pos.empty()) {


### PR DESCRIPTION
Fixed bug #56 remove redundant ",," when outputting the best_model.nex