### PR TITLE
Fix issue when using LSD2 for phylogenetic dating.

### DIFF
--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -3949,6 +3949,10 @@ void runTreeReconstruction(Params &params, IQTree* &iqtree) {
         cout << "Recomputing the log-likelihood of the intermediate trees ... " << endl;
         iqtree->intermediateTrees.recomputeLoglOfAllTrees(*iqtree);
     }
+    //check for dating with LSD2
+    if (params.dating_method == "LSD") {
+        doTimeTree(iqtree);
+    }
     //check for dating with MCMCTree
     if (params.dating_method == "mcmctree")
     {


### PR DESCRIPTION
Adding support for the dating method under LSD2, which is mistakenly disabled.