### PR TITLE
Bug fix: Wrong handling of site-specific state freqs in AliSim

### DIFF
--- a/simulator/alisimulatorheterogeneity.cpp
+++ b/simulator/alisimulatorheterogeneity.cpp
@@ -355,7 +355,8 @@ int AliSimulatorHeterogeneity::estimateStateFromOriginalTransMatrix(ModelSubst *
         #pragma omp critical
         #endif
         {
-            model->setStateFrequency(tmp_state_freqs);
+            model->getMixtureClass(model_component_index)->setStateFrequency(tmp_state_freqs);
+            model->getMixtureClass(model_component_index)->decomposeRateMatrix();
             // compute the transition matrix
             model->computeTransMatrix(combine_rate * branch_length * rate, trans_matrix, model_component_index, dad_state);
         }


### PR DESCRIPTION
In the `AliSimulatorHeterogeneity::estimateStateFromOriginalTransMatrix` function, estimated state frequencies do not get set properly to the site-assigned components of the mixture model and also eigen-stuff of these components is not updated. This pull request fixes the problem.

Commands to run test:
1. simulate the reference "real" alignment:
`iqtree3 -seed 123 -nt 1 --alisim realprot --length 300 -m "LG+G10{0.5}+C60" -t "RANDOM{yh/30}" -rlen 0.05 0.3 1.5 -pre realprot`
2. simulate a new alignment mimicking the reference alignment under the `LG+C10+G4` model and the `MEAN` state frequency mode:
`iqtree3 -seed 123 -nt 1 --alisim simpostmean -s realprot.phy -m "LG+G4+C10" --mix-opt --site-freq MEAN -te realprot.treefile -pre simpostmean`
3. fit the `LG+C10+G4` model to the simulated alignment:
`iqtree3 -seed 123 -nt 1 -s simpostmean.phy -m "LG+G4+C10" --mix-opt -te realprot.treefile -pre fitpostmean`

In the default version comment out the following line in the `AliSimulatorHeterogeneity::estimateStateFromOriginalTransMatrix` function:
`358    model->setStateFrequency(tmp_state_freqs);`
Repeat the steps 2-3 for this modified default version. The `fitpostmean` likelihood doesn't change compared to the default version, as the commented line effectively does nothing.
Repeat the steps 2-3 for the fixed (the PR) version. The `fitpostmean` likelihood is now lower (quite expectedly, as the estimated site-specific state frequencies are further from the C10 mixture than the site-assigned C10 state frequencies).