### PR TITLE
Allow for single-state alignments and remove misleading warnings

### DIFF
--- a/alignment/alignment.h
+++ b/alignment/alignment.h
@@ -484,11 +484,10 @@ public:
     int getMaxSeqNameLength();
 
     /*
-        check if some state is absent, which may cause numerical issues
+        check if some states are absent, which may cause numerical issues
         @param msg additional message into the warning
-        @return number of absent states in the alignment
     */
-    virtual int checkAbsentStates(string msg);
+    virtual void checkAbsentStates(string msg);
 
     /**
             check proper and undupplicated sequence names

--- a/alignment/superalignment.cpp
+++ b/alignment/superalignment.cpp
@@ -1148,11 +1148,9 @@ Alignment *SuperAlignment::removeIdenticalSeq(string not_remove, bool keep_two, 
 	return aln;
 }
 
-int SuperAlignment::checkAbsentStates(string msg) {
-    int count = 0;
-    for (auto it = partitions.begin(); it != partitions.end(); ++it)
-        count += (*it)->checkAbsentStates("partition " + convertIntToString((it-partitions.begin())+1));
-    return count;
+void SuperAlignment::checkAbsentStates(string msg) {
+    for (vector<Alignment*>::iterator it = partitions.begin(); it != partitions.end(); ++it)
+        (*it)->checkAbsentStates("partition " + convertIntToString((it-partitions.begin())+1));
 }
 
 /*

--- a/alignment/superalignment.h
+++ b/alignment/superalignment.h
@@ -171,11 +171,10 @@ public:
 
 
     /*
-        check if some state is absent, which may cause numerical issues
+        check if some states are absent, which may cause numerical issues
         @param msg additional message into the warning
-        @return number of absent states in the alignment
     */
-    virtual int checkAbsentStates(string msg);
+    virtual void checkAbsentStates(string msg);
 
 	/**
 		Quit if some sequences contain only gaps or missing data

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -3403,22 +3403,8 @@ bool isTreeMixture(Params& params) {
 
 void runTreeReconstruction(Params &params, IQTree* &iqtree) {
 
-    //    string dist_file;
-    // params.startCPUTime = getCPUTime();
-    // params.start_real_time = getRealTime();
-    
-    int absent_states = 0;
-    if (iqtree->isSuperTree()) {
-        PhyloSuperTree *stree = (PhyloSuperTree*)iqtree;
-        for (auto i = stree->begin(); i != stree->end(); i++)
-            absent_states += (*i)->aln->checkAbsentStates("partition " + (*i)->aln->name);
-    } else {
-        absent_states = iqtree->aln->checkAbsentStates("alignment");
-    }
-    if (absent_states > 0) {
-        cout << "NOTE: " << absent_states << " states (see above) are not present and thus removed from Markov process to prevent numerical problems" << endl;
-    }
-    
+    iqtree->aln->checkAbsentStates("alignment");
+
     // Make sure that no partial likelihood of IQ-TREE is initialized when PLL is used to save memory
     if (params.pll) {
         iqtree->deleteAllPartialLh();


### PR DESCRIPTION
The current version does not allow an alignment or a partition to have only one state by invoking a hardcoded error. The motivation for this restriction is probably that states not present on tree leaves are assumed to be excluded from the substitution process, hence for a single-state alignment there would be only one state left for modelling substitution process, which would make the observed alignment a certain event given any tree topology and branch lengths (LL = 0).

Here I want to bring your attention to the fallacy of assuming that unrepresented states get excluded from the substitution process. Actually, they do not! Below I provide a simple example in proof:

Let's assume a dummy alignment `dummy.phy`:
```
5 1
1    A
2    A
3    A
4    A
5    A
```
And use it for tree reconstruction after disabling the error raising expression in the `Alignment::checkAbsentStates` function:
`iqtree3 -seed 123 -nt 1 -s dummy.phy --seqtype AA --keep-ident -m "LG" -pre test_dummy_allstates`
`iqtree3 -seed 123 -nt 1 -s dummy.phy --seqtype AA --keep-ident -m "LG+F" -pre test_dummy_onestate`
Both runs finish successfully. The run using the `LG` model results in `LL = -2.537`, while the run using the `LG+F` model results in `LL = 0.0`. All the inferred tree branches have the minimum allowed length (1e-6) in both runs.

The explanation is obvious. The inbuilt state frequencies of the LG matrix used in the first run make it possible for all states to occur in the substitution process, implying that different alignments, not only the given one, can evolve on any tree to be estimated, hence the non-zero LL of the tree estimated for the given alignment. On the contrary, the observed `+F` state frequencies `freq(A, other) = (1.0, 0.0)` used in the second run allow only for the A state in the substitution process, making the evolution of the given alignment inevitable on any tree.
Were unrepresented state frequencies really excluded from the substitution process, we would observe the second run situation for the both runs.

The conclusion is:
- States unrepresented in alignment are not excluded from the substitution process and never have been. Apparently, it is ok and usually does not lead to numerical issues.
- A single-state alignment/partition is suitable for an analysis including branch length optimization, both if only one state or all states are included in the substitution process. It likewise seems not to lead to any issues, but the estimated branch lengths are surely not reliable (due to the scarcity of information).

This pull request allows for single-state alignments/partitions and modifies the warnings in accordance with the conclusion.
The `Alignment::checkAbsentStates` and `SuperAlignment::checkAbsentStates` functions are made to be of the void-returning type because 1) all the relevant information is already printed inside `Alignment::checkAbsentStates` and printing the sum of numbers of unobserved states in `SuperAlignment::checkAbsentStates` (which can easily exceed the num_states) is somewhat misleading, and 2) the number of unobserved states is not used anywhere else. 