### PR TITLE
fix: handle taxa count divisible by 32

### DIFF
--- a/pda/split.cpp
+++ b/pda/split.cpp
@@ -179,6 +179,7 @@ bool Split::compatible(Split &sp)
 	for (iterator it = begin(), sit = sp.begin(); it != end(); it++, sit++)
 	{
 		int num_bits = (it+1 == end()) ? ntaxa % UINT_BITS : UINT_BITS;
+		if (num_bits == 0) num_bits = UINT_BITS; // ntaxa % UINT_BITS == 0
 		UINT it2 = (1 << (num_bits-1)) - 1 + (1 << (num_bits-1)) - (*it);
 		UINT sit2 = (1 << (num_bits-1)) - 1 + (1 << (num_bits-1)) - (*sit);
 


### PR DESCRIPTION
The following snippet crashes under `-fsanitize=undefined` when the number of taxa is a multiple of 32.

https://github.com/iqtree/iqtree3/blob/7cded0cbc1767dab82bed39720a809f9359d7227/pda/split.cpp#L179-L185

The fix simply sets `num_bits` to 32 in that case. It's similar to the fix in https://github.com/iqtree/iqtree2/pull/412. I also manually checked all relevant parts in this file using the same logic.

I think we also need to backport this fix to IQ-TREE 2.