### PR TITLE
Bug fixed: automatically switch to using Parsimony (instead of PLL) to build start trees for very large alignments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -311,13 +311,12 @@ jobs:
         shell: cmd
         run: choco install llvm --version=14.0.6 --allow-downgrade
 
-      - name: Install Boost
-        uses: MarkusJx/install-boost@v2.4.5
-        id: install-boost
-        with:
-          boost_version: 1.84.0
-          platform_version: 2022
-          toolset: mingw
+      - name: Download and Extract Boost 1.84.0
+        shell: pwsh
+        run: |
+          curl -L -o boost.tar.gz https://github.com/MarkusJx/prebuilt-boost/releases/download/1.84.0/boost-1.84.0-windows-2022-mingw-static-x86.tar.gz
+          tar -xzf boost.tar.gz
+          mv boost C:/local/boost
 
       - name: Install Eigen3
         shell: cmd
@@ -334,14 +333,14 @@ jobs:
             -DCMAKE_C_FLAGS=--target=x86_64-pc-windows-gnu ^
             -DCMAKE_CXX_FLAGS=--target=x86_64-pc-windows-gnu ^
             -DCMAKE_MAKE_PROGRAM=mingw32-make ^
-            -DBoost_INCLUDE_DIR=${{steps.install-boost.outputs.BOOST_ROOT}}/include ^
-            -DBoost_LIBRARY_DIRS=${{steps.install-boost.outputs.BOOST_ROOT}}/lib ^
+            -DBoost_INCLUDE_DIR="C:/local/boost/include" ^
+            -DBoost_LIBRARY_DIRS="C:/local/boost/lib" ^
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
             -DIQTREE_FLAGS="static cpp14" ..
           make -j
           make package
         env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+          BOOST_ROOT: "C:/local/boost"
 
       - name: Check File Arch
         shell: bash

--- a/alignment/alignment.cpp
+++ b/alignment/alignment.cpp
@@ -820,6 +820,18 @@ Alignment::Alignment(char *filename, char *sequence_type, InputType &intype, str
              << num_variant_sites-num_informative_sites << " singleton sites, "
              << (int)(frac_const_sites*getNSite()) << " constant sites" << endl;
     }
+    
+    // Bug fix: automatically switch to PARS instead of PLL when #sites * #taxa > 2^31
+    unsigned long int num_taxa_sites = static_cast<unsigned long int>(getNSeq()) * static_cast<unsigned long int>(getNSite());
+    if (num_taxa_sites >= static_cast<unsigned long int>(INT_MAX) && Params::getInstance().start_tree != STT_PARSIMONY)
+    {
+        Params::getInstance().start_tree = STT_PARSIMONY;
+        
+        if (verbose_mode >= VB_MED) {
+            cout << "Switch to using Parsimony to build start trees." << endl;
+        }
+    }
+    
     //buildSeqStates();
     checkSeqName();
     // OBSOLETE: identical sequences are handled later
@@ -860,6 +872,18 @@ Alignment::Alignment(NxsDataBlock *data_block, char *sequence_type, string model
         << num_informative_sites << " parsimony-informative, "
         << num_variant_sites-num_informative_sites << " singleton sites, "
         << (int)(frac_const_sites*getNSite()) << " constant sites" << endl;
+    
+    // Bug fix: automatically switch to PARS instead of PLL when #sites * #taxa > 2^31
+    unsigned long int num_taxa_sites = static_cast<unsigned long int>(getNSeq()) * static_cast<unsigned long int>(getNSite());
+    if (num_taxa_sites >= static_cast<unsigned long int>(INT_MAX) && Params::getInstance().start_tree != STT_PARSIMONY)
+    {
+        Params::getInstance().start_tree = STT_PARSIMONY;
+        
+        if (verbose_mode >= VB_MED) {
+            cout << "Switch to using Parsimony to build start trees." << endl;
+        }
+    }
+    
     //buildSeqStates();
     checkSeqName();
     // OBSOLETE: identical sequences are handled later
@@ -908,6 +932,18 @@ Alignment::Alignment(StrVector& names, StrVector& seqs, char *sequence_type, str
              << num_variant_sites-num_informative_sites << " singleton sites, "
              << (int)(frac_const_sites*getNSite()) << " constant sites" << endl;
     }
+    
+    // Bug fix: automatically switch to PARS instead of PLL when #sites * #taxa > 2^31
+    unsigned long int num_taxa_sites = static_cast<unsigned long int>(getNSeq()) * static_cast<unsigned long int>(getNSite());
+    if (num_taxa_sites >= static_cast<unsigned long int>(INT_MAX) && Params::getInstance().start_tree != STT_PARSIMONY)
+    {
+        Params::getInstance().start_tree = STT_PARSIMONY;
+        
+        if (verbose_mode >= VB_MED) {
+            cout << "Switch to using Parsimony to build start trees." << endl;
+        }
+    }
+    
     //buildSeqStates();
     checkSeqName();
     // OBSOLETE: identical sequences are handled later


### PR DESCRIPTION
This pull request includes:
1. Automatically switch to using Parsimony (instead of PLL) to build start trees for very large alignments (#taxa * #sites >= 2^31).
2. Update the Github workflow to fix the recently emerged error about "Dangerous symlink" when installing Boost on Windows.