### PR TITLE
Bug fixed: delay deleting the "first_insertion" pointer to avoid crashing in partition simulation

### DIFF
--- a/main/alisim.cpp
+++ b/main/alisim.cpp
@@ -1012,6 +1012,13 @@ void generateMultipleAlignmentsFromSingleTree(AliSimulator *super_alisimulator, 
             // otherwise, writing output to file after completing the simulation
             else
                 generatePartitionAlignmentFromSingleSimulator(super_alisimulator, ancestral_sequence, input_msa, site_locked_vec);
+            
+            // Bug fix: delete first_insertion
+            if (super_alisimulator->first_insertion)
+            {
+                delete super_alisimulator->first_insertion;
+                super_alisimulator->first_insertion = nullptr;
+            }
         }
         
         // merge & write alignments to files if they have not yet been written
@@ -1234,8 +1241,9 @@ void generatePartitionAlignmentFromSingleSimulator(AliSimulator *&alisimulator, 
         delete tmp_alisimulator;
 
         // bug fixes: avoid accessing to deallocated pointer
-        if (alisimulator->params->alisim_insertion_ratio + alisimulator->params->alisim_deletion_ratio > 0)
-            alisimulator->first_insertion = nullptr;
+        // Update: we must keep first_insertion for partition model, this pointer will be deleted in a later step
+        /*if (alisimulator->params->alisim_insertion_ratio + alisimulator->params->alisim_deletion_ratio > 0)
+            alisimulator->first_insertion = nullptr;*/
     }
 
 }


### PR DESCRIPTION
Bug fixed: delay deleting the "first_insertion" pointer to avoid crashing in partition simulation.