### PR TITLE
Add option to fix branch lengths to those in the input tree when using fit_tree in libiqtree

### DIFF
--- a/main/libiqtree_fun.h
+++ b/main/libiqtree_fun.h
@@ -74,10 +74,11 @@ extern "C" StringResult build_tree(StringArray& names, StringArray& seqs, const 
 /*
  * Perform phylogenetic analysis on the input alignment
  * With restriction to the input toplogy
+ * blfix -- whether to fix the branch length as those on the given tree, default: false
  * num_thres -- number of cpu threads to be used, default: 1; 0 - auto detection of the optimal number of cpu threads
  * output: results in YAML format with the details of parameters
  */
-extern "C" StringResult fit_tree(StringArray& names, StringArray& seqs, const char* model, const char* intree, int rand_seed = 0, int num_thres = 1);
+extern "C" StringResult fit_tree(StringArray& names, StringArray& seqs, const char* model, const char* intree, bool blfix = false, int rand_seed = 0, int num_thres = 1);
 
 /*
  * Perform phylogenetic analysis with ModelFinder

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2844,16 +2844,20 @@ extern "C" StringResult build_tree(StringArray& names, StringArray& seqs, const 
 
 // Perform phylogenetic analysis on the input alignment (in string format)
 // With restriction to the input toplogy
+// blfix -- whether to fix the branch length as those on the given tree, default: false
 // num_thres -- number of cpu threads to be used, default: 1; 0 - auto detection of the optimal number of cpu threads
-extern "C" StringResult fit_tree(StringArray& names, StringArray& seqs, const char* model, const char* intree, int rand_seed, int num_thres) {
+extern "C" StringResult fit_tree(StringArray& names, StringArray& seqs, const char* model, const char* intree, bool blfix, int rand_seed, int num_thres) {
     StringResult output;
     output.errorStr = strdup("");
     
     try {
         input_options* in_options = NULL;
-        if (num_thres >= 0) {
+        if (num_thres >= 0 || blfix) {
             in_options = new input_options();
-            in_options->insert("-nt", convertIntToString(num_thres));
+            if (num_thres >= 0)
+                in_options->insert("-nt", convertIntToString(num_thres));
+            if (blfix)
+                in_options->insert("-blfix", "");
         }
         string prog = "fit_tree";
         output.value = build_phylogenetic(names, seqs, model, intree, rand_seed, prog, in_options);
@@ -3483,8 +3487,15 @@ void input_options::set_params(Params& params) {
             params.consensus_type = CT_CONSENSUS_TREE;
             params.stop_condition = SC_BOOTSTRAP_CORRELATION;
         }
-        else if (flags[0] == "-nt") {
+        else if (flags[i] == "-nt") {
             params.num_threads = atoi(values[i].c_str());
+        }
+        else if (flags[i] == "-blfix") {
+            params.fixed_branch_length = BRLEN_FIX;
+            params.optimize_alg_gammai = "Brent";
+            params.opt_gammai = false;
+            params.min_iterations = 0;
+            params.stop_condition = SC_FIXED_ITERATION;
         }
     }
 }


### PR DESCRIPTION
This pull request addresses issue: https://github.com/iqtree/piqtree/issues/311

The `fit_tree` function interface in libiqtree has been updated to include a new boolean parameter. This parameter allows users to specify whether the branch lengths should remain fixed to the values provided in the input tree, when a fixed topology is used.

This change allows users more control over tree fitting, ensuring that branch lengths can either be preserved as given or re-estimated as needed.