### PR TITLE
add weighted perturbation

### DIFF
--- a/tree/iqtree.cpp
+++ b/tree/iqtree.cpp
@@ -1679,6 +1679,65 @@ string IQTree::perturbStableSplits(double suppValue) {
     return getTreeString();
 }
 
+static double branchLengthSafe(const Branch& b) {
+    Node* u = b.first;
+    Node* v = b.second;
+    double L = 0.0;
+
+    if (Neighbor* n = u->findNeighbor(v)) {
+        L = n->length;
+    } else if (Neighbor* m = v->findNeighbor(u)) {
+        L = m->length;
+    }
+
+    if (!(L >= 0.0) || std::isnan(L)) {
+        L = 0.0;
+    }
+
+    return L;
+}
+
+static std::vector<double> computeRankOverE(const std::vector<Branch>& branches,
+                                            const std::vector<double>& lengths) {
+    const size_t E = branches.size();
+
+    std::vector<size_t> idx(E);
+    std::iota(idx.begin(), idx.end(), 0);
+
+    std::sort(idx.begin(), idx.end(),
+              [&](size_t i, size_t j) {
+                  return lengths[i] < lengths[j];
+              });
+
+    std::vector<double> rOverE(E, 0.0);
+
+    for (size_t r = 0; r < E; ++r) {
+        rOverE[idx[r]] = static_cast<double>(r + 1) / static_cast<double>(E); // 1..E → (0,1]
+    }
+
+    return rOverE;
+}
+
+static int sampleIndexByWeights(const std::vector<double>& w) {
+    double sumW = 0.0;
+    for (double x : w) {
+        sumW += x;
+    }
+    if (!(sumW > 0.0)) {
+        return random_int((int)w.size()); // uniform fallback
+    }
+    const double u = random_double() * sumW;
+    double acc = 0.0;
+
+    for (size_t i = 0; i < w.size(); ++i) {
+        acc += w[i];
+        if (u <= acc) {
+            return (int)i;
+        }
+    }
+    return (int)w.size() - 1;
+}
+
 string IQTree::doRandomNNIs(bool storeTabu) {
     int cntNNI = 0;
     int numRandomNNI;
@@ -1706,8 +1765,52 @@ string IQTree::doRandomNNIs(bool storeTabu) {
         for (Branches::iterator it = nniBranches.begin(); it != nniBranches.end(); ++it) {
             vectorNNIBranches.push_back(it->second);
         }
-        int randInt = random_int((int) vectorNNIBranches.size());
-        NNIMove randNNI = getRandomNNI(vectorNNIBranches[randInt]);
+        
+        int pickedIndex = -1;
+        if (!Params::getInstance().weightedPerturbation || vectorNNIBranches.size() == 1) {
+            // default: uniform
+            pickedIndex = random_int(static_cast<int>(vectorNNIBranches.size()));
+        } else {
+            // weighted: w_i = (beta*Lmed + rank_i/E)^(-alpha)
+            const double alpha = 64.0;
+            const double beta  = 0.5;
+            constexpr double eps = 1e-12;
+
+            std::vector<double> lengths;
+            lengths.reserve(vectorNNIBranches.size());
+
+            for (const auto& br : vectorNNIBranches) {
+                lengths.push_back(branchLengthSafe(br));
+            }
+
+            double Lmed = 0.0;
+            if (!lengths.empty()) {
+                std::vector<double> sorted = lengths;
+                std::sort(sorted.begin(), sorted.end());
+
+                const size_t E = sorted.size();
+                if (E % 2 == 0) {
+                    Lmed = 0.5 * (sorted[E / 2 - 1] + sorted[E / 2]);
+                } else {
+                    Lmed = sorted[E / 2];
+                }
+            }
+
+            std::vector<double> rOverE = computeRankOverE(vectorNNIBranches, lengths);
+
+            const double shift = std::max(beta * Lmed, eps);
+            std::vector<double> w(rOverE.size());
+
+            for (size_t i = 0; i < rOverE.size(); ++i) {
+                const double base = shift + rOverE[i];
+                w[i] = std::pow(base, -alpha);
+            }
+
+            pickedIndex = sampleIndexByWeights(w);
+        }
+
+        NNIMove randNNI = getRandomNNI(vectorNNIBranches[pickedIndex]);
+        
         if (constraintTree.isCompatible(randNNI)) {
             // only if random NNI satisfies constraintTree
             doNNI(randNNI);

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -5099,6 +5099,11 @@ void parseArg(int argc, char *argv[], Params &params) {
                 continue;
             }
 
+            if (strcmp(argv[cnt], "--weighted-perturbation") == 0 || strcmp(argv[cnt], "-weighted-perturbation") == 0) {
+                params.weightedPerturbation = true;
+                continue;
+            }
+
 //			if (strcmp(argv[cnt], "-rootstate") == 0) {
 //                cnt++;
 //                if (cnt >= argc)
@@ -7831,6 +7836,7 @@ void Params::setDefault() {
     new_heuristic = true;
     iteration_multiple = 1;
     initPS = 0.5;
+    weightedPerturbation = false;
 #ifdef USING_PLL
     pll = true;
 #else

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -765,6 +765,11 @@ public:
 	 */
 	double initPS;
 
+    /**
+     * a switch to apply bias towards shorter branches during radom perturbation
+     */
+    bool weightedPerturbation;
+    
 	/**
 	 *  logl epsilon for model parameter optimization
 	 */


### PR DESCRIPTION
This pull request includes branch-length-weighted NNI sampling, aimed at enhancing the speed with minimal impact on topological accuracy.

## Changes

- Added the flag ```--weighted-perturbation``` (default=```false```)
- Modified the NNI sampling routine to weight branch perturbations by branch length
- Minor updates to parameter handling

## Validation

- Evaluated on 72 tree pairs (baseline vs. weighted-perturbation) (18 alignment files × 4 random seeds)
- All passed the approximately unbiased (AU) test with *p > 0.05*, indicating no significant difference in accuracy.
- The attached file contains detailed test results.
- [au_test_summary.csv](https://github.com/user-attachments/files/23100791/au_test_summary.csv)
