### PR TITLE
clamped_uint.cpp: Fix duplicate instantiation errors with Clang 21

### DIFF
--- a/terraphast/lib/clamped_uint.cpp
+++ b/terraphast/lib/clamped_uint.cpp
@@ -90,14 +90,10 @@ template class checked_uint<false>;
 template class checked_uint<true>;
 
 // explicitly instantiate template functions
-template bool operator==(checked_uint<false>, checked_uint<false>);
-template bool operator!=(checked_uint<false>, checked_uint<false>);
 template checked_uint<false> operator+(checked_uint<false>, checked_uint<false>);
 template checked_uint<false> operator*(checked_uint<false>, checked_uint<false>);
 template std::ostream& operator<<(std::ostream&, checked_uint<false>);
 
-template bool operator==(checked_uint<true>, checked_uint<true>);
-template bool operator!=(checked_uint<true>, checked_uint<true>);
 template checked_uint<true> operator+(checked_uint<true>, checked_uint<true>);
 template checked_uint<true> operator*(checked_uint<true>, checked_uint<true>);
 template std::ostream& operator<<(std::ostream&, checked_uint<true>);


### PR DESCRIPTION
The build was failing on FreeBSD/main after the import of clang 21.

Remove redundant explicit instantiations of template function in terraphast/lib/clamped_uint.cpp.  The preceding `template class` lines already instantiate the member functions, and the free function templates (operator== and operator!=) are defined in the same translation unit and will be instantiated on demand.

Clang 21 now rejects these as duplicate definitions.