### PR TITLE
Bug fix for PMSF+I combinations

### DIFF
--- a/model/modelset.cpp
+++ b/model/modelset.cpp
@@ -125,6 +125,16 @@ void ModelSet::writeInfo(ostream& out)
 	}
 }
 
+void ModelSet::getStateFrequency(double *state_freq, int mixture) {
+    ASSERT(mixture >= -1);
+    if (mixture >= 0) {
+        at(mixture)->getStateFrequency(state_freq);
+        return;
+    }
+    // default: return the +F freqs across all patterns
+    ModelMarkov::getStateFrequency(state_freq);
+}
+
 void ModelSet::decomposeRateMatrix()
 {
     if (empty()) {

--- a/model/modelset.h
+++ b/model/modelset.h
@@ -130,6 +130,13 @@ public:
 	*/
 	virtual void writeInfo(ostream &out);
 
+    /**
+     *  Compute the state frequency vector
+     *  @param mixture Submodel id of the state frequency vector, 0 for default frequencies
+     *  @param[out] state_freq State frequency vector, must have the size of num_states
+     */
+    virtual void getStateFrequency(double *state_freq, int mixture = 0);
+
 	/**
 		decompose the rate matrix into eigenvalues and eigenvectors
 	*/

--- a/model/modelset.h
+++ b/model/modelset.h
@@ -135,7 +135,7 @@ public:
      *  @param mixture Submodel id of the state frequency vector, 0 for default frequencies
      *  @param[out] state_freq State frequency vector, must have the size of num_states
      */
-    virtual void getStateFrequency(double *state_freq, int mixture = 0);
+    virtual void getStateFrequency(double *state_freq, int mixture = -1);
 
 	/**
 		decompose the rate matrix into eigenvalues and eigenvectors

--- a/tree/phylotreesse.cpp
+++ b/tree/phylotreesse.cpp
@@ -547,68 +547,71 @@ void PhyloTree::computePtnFreq() {
 }
 
 void PhyloTree::computePtnInvar() {
-	size_t nptn = aln->getNPattern(), ptn;
-	size_t maxptn = get_safe_upper_limit(nptn)+get_safe_upper_limit(model_factory->unobserved_ptns.size());
-  // For PoMo, only consider monomorphic states and set nstates to the number of
-  // states of the underlying mutation model.
-	int nstates = model->getMutationModel()->num_states;
-    int x;
-    // ambiguous characters
+    size_t nptn = aln->getNPattern();
+    size_t maxptn = get_safe_upper_limit(nptn)+get_safe_upper_limit(model_factory->unobserved_ptns.size());
+    // set nstates:
+    // - for PoMo: to the number of monomorphic (boundary) states
+    // - for other models: to the number of states of the model
+    int nstates = model->getMutationModel()->num_states;
+    // protein ambiguous characters
     int ambi_aa[] = {
-        4+8, // B = N or D
-        32+64, // Z = Q or E
-        512+1024 // U = I or L
+        4+8,     // B = N or D
+        32+64,   // Z = Q or E
+        512+1024 // J = I or L
     };
-
+    // set state_freq:
+    // - for PoMo: to the stationary freqs of monomorphic (boundary) states
+    // - for SSF: to the site-specific stationary freqs, for each pattern below
+    // - for other models: to the stationary freqs of the model
     double state_freq[nstates];
-
-    // -1 for mixture model
-
-    // Again for PoMo, the stationary frequencies are set to the stationary
-    // frequencies of the boundary states.
     model->getMutationModel()->getStateFrequency(state_freq, -1);
-
-	memset(ptn_invar, 0, maxptn*sizeof(double));
-	double p_invar = site_rate->getPInvar();
-	if (p_invar != 0.0) {
-		for (ptn = 0; ptn < nptn; ptn++) {
-            if ((*aln)[ptn].const_char > aln->STATE_UNKNOWN)
+    memset(ptn_invar, 0, maxptn*sizeof(double));
+    double p_invar = site_rate->getPInvar();
+    if (p_invar) {
+        for (size_t ptn = 0; ptn < nptn; ++ptn) {
+            if (model->isSiteSpecificModel()) {
+                model->getStateFrequency(state_freq, ptn);
+            }
+            int cstate = aln->at(ptn).const_char;
+            if (cstate > aln->STATE_UNKNOWN) {
+                // var pattern or PoMo polymorphic const pattern
                 continue;
-
-			if ((*aln)[ptn].const_char == aln->STATE_UNKNOWN) {
-				ptn_invar[ptn] = p_invar;
-        // For PoMo, if a polymorphic state is considered, the likelihood is
-        // left unchanged and zero because ptn_invar has been initialized to 0.
-			} else if ((*aln)[ptn].const_char < nstates) {
-				ptn_invar[ptn] = p_invar * state_freq[(int) (*aln)[ptn].const_char];
-			} else if (aln->seq_type == SEQ_DNA) {
-                // 2016-12-21: handling ambiguous state
-                ptn_invar[ptn] = 0.0;
-                int cstate = (*aln)[ptn].const_char-nstates+1;
-                for (x = 0; x < nstates; x++) {
-                    if ((cstate) & (1 << x))
+            } else if (cstate == aln->STATE_UNKNOWN) {
+                // gap-only pattern
+                ptn_invar[ptn] = p_invar;
+            } else if (cstate < nstates) {
+                // const pattern
+                ptn_invar[ptn] = p_invar * state_freq[cstate];
+            } else if (aln->seq_type == SEQ_DNA) {
+                // invar pattern: handling DNA ambiguous state
+                int astate = cstate - nstates + 1;
+                ASSERT(astate <= 14);
+                for (int x = 0; x < nstates; ++x) {
+                    if (astate & (1 << x)) {
                         ptn_invar[ptn] += state_freq[x];
+                    }
                 }
                 ptn_invar[ptn] *= p_invar;
             } else if (aln->seq_type == SEQ_PROTEIN) {
-                ptn_invar[ptn] = 0.0;
-                int cstate = (*aln)[ptn].const_char-nstates;
-                ASSERT(cstate <= 2);
-                for (x = 0; x < 11; x++)
-                    if (ambi_aa[cstate] & (1 << x))
+                // invar pattern: handling protein ambiguous state
+                int astate = cstate - nstates;
+                ASSERT(astate <= 2);
+                for (int x = 0; x < 11; ++x) {
+                    if (ambi_aa[astate] & (1 << x)) {
                         ptn_invar[ptn] += state_freq[x];
+                    }
+                }
                 ptn_invar[ptn] *= p_invar;
-            } else ASSERT(0);
-		}
-//		// ascertmain bias correction
-//		for (ptn = 0; ptn < model_factory->unobserved_ptns.size(); ptn++)
-//			ptn_invar[nptn+ptn] = p_invar * state_freq[(int)model_factory->unobserved_ptns[ptn]];
-//
-		// dummy values
-		for (ptn = nptn; ptn < maxptn; ptn++)
-			ptn_invar[ptn] = p_invar;
-	}
-//	aligned_free(state_freq);
+            } else {
+                // invar pattern: not defined for other data types
+                ASSERT(0);
+            }
+        }
+        // dummy values
+        for (size_t ptn = nptn; ptn < maxptn; ++ptn) {
+            ptn_invar[ptn] = p_invar;
+        }
+    }
 }
 
 /*******************************************************


### PR DESCRIPTION
This pull request fixes #58 by using site-specific state frequencies to compute `ptn_invar` for invariant patterns in the `PhyloTree::computePtnInvar()` function under the PMSF model.