### PR TITLE
Fix EM mixture-frequency optimization

### DIFF
--- a/model/modelmixture.cpp
+++ b/model/modelmixture.cpp
@@ -4177,6 +4177,7 @@ double ModelMixture::optimizeWithEM(double gradient_epsilon) {
     // EM algorithm loop described in Wang, Li, Susko, and Roger (2008)
     for (step = 0; step < optimize_steps; step++) {
         // first compute _pattern_lh_cat
+        phylo_tree->clearAllPartialLH();
         score = phylo_tree->computePatternLhCat(WSL_MIXTURE);
 
         if (score < prev_score + gradient_epsilon)
@@ -4254,6 +4255,7 @@ double ModelMixture::optimizeWithEM(double gradient_epsilon) {
 
             if (c>0 && !Params::getInstance().optimize_linked_gtr) {
                 // compute _pattern_lh_cat
+                phylo_tree->clearAllPartialLH();
                 phylo_tree->computePatternLhCat(WSL_MIXTURE);
                 // update the posterior probabilities of each category
                 for (ptn = 0; ptn < nptn; ptn++) {


### PR DESCRIPTION
Two fixes in `ModelMixture::optimizeWithEM` (used by `-mfopt -optalg_qmix EM`). The issues were reported by Ryo.

1. _EM made the result worse instead of better_ (the final log-likelihood was lower than the start). The  E-step used old partial-likelihood values that were not updated for the current model, so the per-class weights were wrong. Fix: call `clearAllPartialLH()` before each `computePatternLhCat` that builds the weights, so the values are recomputed. 

2. _Crash when `-mem` is used_.  Fix: copy `max_lh_slots` to the inner tree.

- Tested on LG+C10+G4 (20 taxa, 5000 sites): EM now improves correctly, runs with `-mem 4G` and `-mem 1G` without crashing, and  the non-`-mem` and BFGS runs are unchanged.