### PR TITLE
Bug fixes AliSim: buffer overflow and very short branches/partitions

### DIFF
--- a/simulator/alisimulator.cpp
+++ b/simulator/alisimulator.cpp
@@ -150,7 +150,11 @@ void AliSimulator::initializeIQTreeFromTreeFile()
             pat.resize(current_tree->aln->getNSeq(), current_tree->aln->STATE_UNKNOWN);
             pat.frequency = expected_num_states_current_tree;
             current_tree->aln->addPattern(pat);
-            
+            // update num_variant_sites/num_informative_sites to match the fake pattern just added;
+            // orderPatternByNumChars() (called inside initializeModel() below) sizes its internal
+            // buffer off these counts, and a mismatch here overflows that buffer
+            current_tree->aln->countConstSites();
+
             // initialize the model for the current partition
             initializeModel(current_tree, current_tree->aln->model_name);
             

--- a/simulator/alisimulator.cpp
+++ b/simulator/alisimulator.cpp
@@ -149,11 +149,8 @@ void AliSimulator::initializeIQTreeFromTreeFile()
             Pattern pat;
             pat.resize(current_tree->aln->getNSeq(), current_tree->aln->STATE_UNKNOWN);
             pat.frequency = expected_num_states_current_tree;
+            pat.flag = PAT_INVARIANT;
             current_tree->aln->addPattern(pat);
-            // update num_variant_sites/num_informative_sites to match the fake pattern just added;
-            // orderPatternByNumChars() (called inside initializeModel() below) sizes its internal
-            // buffer off these counts, and a mismatch here overflows that buffer
-            current_tree->aln->countConstSites();
 
             // initialize the model for the current partition
             initializeModel(current_tree, current_tree->aln->model_name);

--- a/simulator/alisimulator.cpp
+++ b/simulator/alisimulator.cpp
@@ -2862,7 +2862,7 @@ void AliSimulator::simulateSeqByGillespie(int segment_start, int &segment_length
     int ori_seq_length = node_seq_chunk.size();
     Insertion* insertion_before_simulation = latest_insertion;
     
-    double branch_length = (*it)->length * params->alisim_branch_scale;
+    double branch_length = (*it)->length * params->alisim_branch_scale * partition_rate;
     while (branch_length > 0)
     {
         // generate a waiting time s1 by sampling from the exponential distribution with mean 1/total_event_rate


### PR DESCRIPTION
This pull request includes:
1. Fix the crash due to heap buffer overflow on the refactored alignment.
2. Bug fix: adding the partition rate to the Gillespie algorithm. This bug affects special cases when using partition rates (-p) with very short branch lengths or partition sequence lengths (e.g., 1 site per partition). Thanks, Mattia, for reporting this.