### PR TITLE
Bug fix: stop using dangling ptrs and buildPattern() in fixPartitions()

### DIFF
--- a/main/phylotesting.cpp
+++ b/main/phylotesting.cpp
@@ -1910,22 +1910,20 @@ PhyloSuperTree* mergePartitions(PhyloSuperTree* super_tree, vector<set<int> > &g
 }
 
 /**
- called when some partition is changed
+ *  Called after some partitions could be changed by ModelOMatic
  */
-void fixPartitions(PhyloSuperTree* super_tree) {
-    SuperAlignment *super_aln = (SuperAlignment*)super_tree->aln;
-    int part;
-    bool aln_changed = false;
-    for (part = 0; part < super_tree->size(); part++)
-        if (super_aln->partitions[part] != super_tree->at(part)->aln) {
-            aln_changed = true;
-            super_aln->partitions[part] = super_tree->at(part)->aln;
-        }
-    if (!aln_changed)
-        return;
-    super_aln->buildPattern();
-    super_aln->orderPatternByNumChars(PAT_VARIANT);
-    super_tree->deleteAllPartialLh();
+static void fixPartitions(PhyloSuperTree *stree) {
+    // Alignments of some subtrees might have changed seq_type
+    // (from CODON to DNA or PROT), but we don't know which ones.
+    // They are dangling pointers in saln->partitions now, so we
+    // reset all partitions and recompute all relevant info in saln
+    SuperAlignment *saln = (SuperAlignment*)stree->aln;
+    for (size_t part = 0; part < stree->size(); ++part) {
+        saln->partitions[part] = stree->at(part)->aln;
+    }
+    saln->countConstSites();
+    saln->orderPatternByNumChars(PAT_VARIANT);
+    stree->deleteAllPartialLh();
 }
 
 string CandidateModel::evaluate(Params &params,


### PR DESCRIPTION
This pull request fixes two issues in the `fixPartitions()` function from `phylotesting.cpp`:
1. ModelOMatic can change some subalignments effectively through the `stree->at(i)->aln` pointers. This means that the respective `saln->partitions[i]` pointers remain dangling, as they cannot be reset in place due to the general code design. Comparison with a dangling pointer has an implementation-specific behaviour in c++, it might work or might not.
Therefore, I opt to avoid it here simply by unconditionally resetting all `saln->partitions` pointers and relevant `saln` info (see below). This means that now the reset happens for each PartitionFinder call, but since it happens only once, the time overhead is negligible.
2. After my recent alignment refactoring, `SuperAlignment::buildPattern()` expects that the alignment pattern vector is empty. This guarantees that the function is used only during superalignment initialization, as any other usage would likely be incorrect.
Here, in `fixPartitions()`, we change sequence types of subalignments (and hence their pattern numbers and contents), but the patterns of taxon presence/absence remain the same. So `saln->taxa_index` remains the same as well and it would be pointless to call `saln->buildPattern()`, even if we could. But since the pattern contents of the subalignments might have changed, we have to call `saln->computeConstSites()` and `saln->orderPatternByNumChars` here. 