### PR TITLE
Fix AliSim crashing when using GHOST with a partitioned/mixed-datatype models

### DIFF
--- a/simulator/alisimulator.cpp
+++ b/simulator/alisimulator.cpp
@@ -166,10 +166,15 @@ void AliSimulator::initializeIQTreeFromTreeFile()
                 
                 // set the new PhyloTreeMixlen to the new tree
                 current_tree = new_tree;
-                
+
+                // update the pointer stored in the super tree's vector of partition
+                // trees; otherwise it keeps referencing the just-deleted old tree,
+                // causing a dangling-pointer crash later (e.g. in initSequences())
+                ((PhyloSuperTree*) tree)->at(i) = current_tree;
+
                 // re-load the tree/branch-lengths from the file
                 current_tree->IQTree::readTree(params->user_file, is_rooted, tree_line_index);
-                
+
                 // re-initialize the model
                 initializeModel(current_tree, current_tree->aln->model_name);
             }


### PR DESCRIPTION
This pull request fixes a crash when AliSim simulates alignments using GHOST with partitioned/mixed-datatype models because of a deleted tree pointer. This bug was reported in [the iqtree2 repo](https://github.com/iqtree/iqtree2/issues/537).
Solution: set the pointer to the correct (newly-created) PhyloTreeMixlen tree.