### PR TITLE
Bug fix: uniformly select indel positions across only non-gap sites

### DIFF
--- a/simulator/alisimulator.cpp
+++ b/simulator/alisimulator.cpp
@@ -3237,24 +3237,34 @@ void AliSimulator::handleSubs(int segment_start, double &total_sub_rate, vector<
 int AliSimulator::selectValidPositionForIndels(int upper_bound, vector<short int> &sequence)
 {
     int position = -1;
+    // fast path: rejection sampling. Cheap (O(1) amortized) whenever gaps are
+    // not the majority of the sequence, and unbiased: every live site has the
+    // same probability of being picked, regardless of the surrounding gaps.
     for (int i = 0; i < upper_bound; i++)
     {
         position = random_int(upper_bound);
-        
-        // try to move to the following site if the selected site is a gap
-        if (position < sequence.size() && sequence[position] == STATE_UNKNOWN)
-            for (; position < upper_bound; position++)
-                if (position == sequence.size() || sequence[position] != STATE_UNKNOWN)
-                    break;
-        
+
         // a valid position must not be a deleted site
         if (position == sequence.size() || sequence[position] != STATE_UNKNOWN)
-            break;
+            return position;
     }
-    // validate the position
-    if (position < sequence.size() && sequence[position] == STATE_UNKNOWN)
+
+    // fallback: the sequence is heavily gapped, so random draws kept missing
+    // the live sites within the attempt budget above. Rather than erroring
+    // out on bad luck, collect all valid positions once and pick uniformly
+    // among them. Still exactly unbiased, just O(upper_bound) instead of
+    // O(1); only taken in this rare, heavily-gapped case.
+    vector<int> valid_positions;
+    valid_positions.reserve(upper_bound); // at most upper_bound valid positions exist, so this is a single allocation
+    for (int i = 0; i < upper_bound; i++)
+        if (i == sequence.size() || sequence[i] != STATE_UNKNOWN)
+            valid_positions.push_back(i);
+
+    // validate that at least one valid position exists
+    if (valid_positions.empty())
         outError("Sorry! Could not select a valid position (not a deleted-site) for insertion/deletion events. You may specify a too high deletion rate, thus almost all sites were deleted. Please try again a a smaller deletion ratio!");
-    return position;
+
+    return valid_positions[random_int((int)valid_positions.size())];
 }
 
 /**

--- a/simulator/alisimulator.cpp
+++ b/simulator/alisimulator.cpp
@@ -3237,9 +3237,9 @@ void AliSimulator::handleSubs(int segment_start, double &total_sub_rate, vector<
 int AliSimulator::selectValidPositionForIndels(int upper_bound, vector<short int> &sequence)
 {
     int position = -1;
-    // fast path: rejection sampling. Cheap (O(1) amortized) whenever gaps are
-    // not the majority of the sequence, and unbiased: every live site has the
-    // same probability of being picked, regardless of the surrounding gaps.
+    // Fast random site selection: select a site across only non-gapped sites.
+    // max attempts: upper_bound.
+    // Cheap (O(1) amortized) whenever gaps are not the majority of the sequence
     for (int i = 0; i < upper_bound; i++)
     {
         position = random_int(upper_bound);
@@ -3249,13 +3249,11 @@ int AliSimulator::selectValidPositionForIndels(int upper_bound, vector<short int
             return position;
     }
 
-    // fallback: the sequence is heavily gapped, so random draws kept missing
-    // the live sites within the attempt budget above. Rather than erroring
-    // out on bad luck, collect all valid positions once and pick uniformly
-    // among them. Still exactly unbiased, just O(upper_bound) instead of
-    // O(1); only taken in this rare, heavily-gapped case.
+    // Fallback: when the sequence is heavily gapped (i.e., extreme cases), so random draws kept missing
+    // the non-gapped sites within the max attempts.
+    // Collect all non-gapped positions once and pick uniformly among them.
     vector<int> valid_positions;
-    valid_positions.reserve(upper_bound); // at most upper_bound valid positions exist, so this is a single allocation
+    valid_positions.reserve(upper_bound);
     for (int i = 0; i < upper_bound; i++)
         if (i == sequence.size() || sequence[i] != STATE_UNKNOWN)
             valid_positions.push_back(i);


### PR DESCRIPTION
**Issue:** When an indel event occurs, AliSim picks a random site across the entire sequence, including both gapped and non-gapped sites. If it lands on a gapped site, AliSim shifts forward to the nearest non-gapped site and uses that instead. This makes site selection non-uniform - sites right after existing gaps are more likely to be picked than others. 

**Solution:** AliSim now selects uniformly among only the non-gapped sites.