### PR TITLE
PartitionFinder-mAIC improvement

### DIFF
--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -926,13 +926,13 @@ void reportTree(ofstream &out, Params &params, PhyloTree &tree, double tree_lh, 
     // mAIC report
     if (tree.isSuperTree() && params.partition_type != TOPO_UNLINKED) {
         // compute mAIC/mBIC/mAICc if it is a partition model
-        double mix_lh = tree.getModelFactory()->computeMarginalLh(params.remove_empty_seq);
+        double mar_lh = tree.getModelFactory()->getMarginalLh(params.remove_empty_seq);
 
         double mAIC, mAICc, mBIC;
-        computeInformationScores(mix_lh, df, ssize, mAIC, mAICc, mBIC);
+        computeInformationScores(mar_lh, df, ssize, mAIC, mAICc, mBIC);
 
         out << endl;
-        out << "Marginal log-likelihood of the tree: " << mix_lh << endl;
+        out << "Marginal log-likelihood of the tree: " << mar_lh << endl;
         out << "Marginal Akaike information criterion (mAIC) score: " << mAIC << endl;
         //out << "Marginal corrected Akaike information criterion (mAICc) score: " << mAICc << endl;
         //out << "Marginal Bayesian information criterion (mBIC) score: " << mBIC << endl;
@@ -3995,6 +3995,12 @@ void runTreeReconstruction(Params &params, IQTree* &iqtree) {
         cout << iqtree->collapseInternalBranches(nullptr, nullptr, params.min_branch_length*4);
         cout << " collapsed" << endl;
     }
+
+    // Pre-compute the marginal log-likelihood (mAIC) here, before the total runtime is
+    // reported, so its cost is included in the reported time. reportTree then just loads
+    // and prints the cached value like AIC/BIC.
+    if (iqtree->isSuperTree() && params.partition_type != TOPO_UNLINKED)
+        iqtree->getModelFactory()->getMarginalLh(params.remove_empty_seq);
 
     printFinalSearchInfo(params, *iqtree, search_cpu_time, search_real_time);
 

--- a/main/phylotesting.cpp
+++ b/main/phylotesting.cpp
@@ -4441,7 +4441,11 @@ double PartitionFinder::getmAICforMergeScheme(vector<set<int> > gene_sets, StrVe
     }
     lh_marginal = maic_tree->getModelFactory()->computeMarginalLh(params->remove_empty_seq);
     score_maic = computeInformationScore(lh_marginal, df, ssize, MTC_AIC);
+
+    // when applying mergePartition(), the newly generated aln must be freed.
+    Alignment *maic_aln = merge ? maic_tree->aln : nullptr;
     delete maic_tree;
+    delete maic_aln;
 
     return score_maic;
 }

--- a/main/phylotesting.cpp
+++ b/main/phylotesting.cpp
@@ -4408,7 +4408,7 @@ void PartitionFinder::getBestModelforMergesMPI(int nthreads, vector<MergeJob* >&
 
 #endif // _IQTREE_MPI
 
-double PartitionFinder::getmAICforMergeScheme(vector<set<int> > gene_sets, StrVector model_names, int df, bool merge) {
+double PartitionFinder::getmAICforMergeScheme(vector<set<int> > gene_sets, StrVector model_names, int df, bool merge, bool warmup_cache) {
     PhyloSuperTree *maic_tree;
     double score_maic;
     if (merge) {
@@ -4439,6 +4439,15 @@ double PartitionFinder::getmAICforMergeScheme(vector<set<int> > gene_sets, StrVe
         maic_tree->at(j)->getModelFactory()->restoreCheckpoint();
         model_info->endStruct();
     }
+    // share the per-column cache with the marginal-LH computation (merge-round candidates only)
+    // cache for merged-scheme evaluations (merge==true) and for the one-off initial full-scheme
+    // call (warmup_cache==true: it computes exactly the original-partition columns round 1 reuses).
+    // The final full-scheme call (merge==false, warmup_cache==false) runs the original uncached path.
+    if (merge || warmup_cache) {
+        PartitionModel *pm = (PartitionModel*) maic_tree->getModelFactory();
+        pm->maic_cache = &maic_subcol_cache;
+        pm->maic_blocks = &maic_current_blocks;
+    }
     lh_marginal = maic_tree->getModelFactory()->computeMarginalLh(params->remove_empty_seq);
     score_maic = computeInformationScore(lh_marginal, df, ssize, MTC_AIC);
 
@@ -4450,11 +4459,48 @@ double PartitionFinder::getmAICforMergeScheme(vector<set<int> > gene_sets, StrVe
     return score_maic;
 }
 
+// Drop every cached column whose data- or class-block overlaps the just-merged partition set,
+// except columns of the newly merged block itself.
+void PartitionFinder::evictMergedFromCache(set<int> &merged_set) {
+    if (maic_subcol_cache.empty())
+        return;
+    set<string> merged_names;                       // names of the absorbed original partitions
+    for (int idx : merged_set)
+        merged_names.insert(in_tree->at(idx)->aln->name);
+    string merged_block = getSubsetName(in_tree, merged_set); // name of the new merged block
+
+    auto blockDead = [&](const string &name, size_t begin, size_t end) -> bool {
+        if (name.compare(begin, end - begin, merged_block) == 0)
+            return false;                           // the new merged block itself: keep
+        size_t p = begin;
+        while (p < end) {
+            size_t plus = name.find('+', p);
+            if (plus == string::npos || plus > end) plus = end;
+            if (merged_names.count(name.substr(p, plus - p)))
+                return true;                        // shares an absorbed partition: dead
+            p = plus + 1;
+        }
+        return false;
+    };
+
+    for (auto it = maic_subcol_cache.begin(); it != maic_subcol_cache.end(); ) {
+        const string &key = it->first;              // "<data>\x01<class>"
+        size_t sep = key.find('\x01');
+        bool dead = blockDead(key, 0, sep) || blockDead(key, sep + 1, key.size());
+        if (dead) it = maic_subcol_cache.erase(it);
+        else ++it;
+    }
+}
 
 ModelPairSet PartitionFinder::getBetterPairsmAIC() {
     cout << "Compute mAIC score of partition models..." << endl;
     double cpu_time = getCPUTime();
     double real_time = getRealTime();
+
+    // reload this round's cacheable blocks from gene_sets.
+    maic_current_blocks.clear();
+    for (auto &gs : gene_sets)
+        maic_current_blocks.insert(getSubsetName(in_tree, gs));
 
     double cur_score_maic = 0;
     double greedy_lh_marginal;
@@ -4505,6 +4551,12 @@ ModelPairSet PartitionFinder::getBetterPairsmAIC() {
                 part_ids.insert(it->second.merged_set.begin(), it->second.merged_set.end());
                 cur_better_pairs.insertPair(it_bu->second);
 
+                // update the cacheable-block set
+                maic_current_blocks.erase(getSubsetName(in_tree, better_gene_sets[cur_pair.part1]));
+                maic_current_blocks.erase(getSubsetName(in_tree, better_gene_sets[cur_pair.part2]));
+                evictMergedFromCache(cur_pair.merged_set);
+                maic_current_blocks.insert(getSubsetName(in_tree, cur_pair.merged_set));
+
                 inf_score_maic = cur_score_maic;
                 better_df = cur_df;
                 better_gene_sets = cur_gene_sets;
@@ -4544,6 +4596,11 @@ ModelPairSet PartitionFinder::getBetterPairsmAIC() {
         int cur_df = dfsum - dfvec[it->second.part1] - dfvec[it->second.part2] + it->second.df;
         cout << "Merging " << it->second.set_name << " with mAIC score: " << greedy_score_maic
              << " (Marginal LnL: " << greedy_lh_marginal << "  df: " << cur_df << ")" << endl;
+        // greedy commits exactly this one pair (in test_PartitionModel); evict the columns of
+        // the two absorbed blocks here, symmetric with the cluster path above. The newly merged
+        // block becomes cacheable next round via the round-start reload of maic_current_blocks.
+        ModelPair best_pair = it->second;
+        evictMergedFromCache(best_pair.merged_set);
     }
     cout << cur_better_pairs.size() << " compatible better partition pairs found based on mAIC" << endl;
     /*if (cur_better_pairs.size() == 0 && better_pairs.size() == 0) {
@@ -5326,6 +5383,11 @@ void PartitionFinder::test_PartitionModel() {
 
     if (params->partition_merge != MERGE_NONE) {
         // show the parameters for partition finder
+        if (params->marginal_lh_aic) {
+            size_t mem_cache = (in_tree->size() + 1) * ssize * sizeof(double);
+            cout << "NOTE: mAIC marginal likelihood cache during merging requires up to "
+                 << (mem_cache / 1048576) << " MB RAM (" << (mem_cache / 1073741824) << " GB)!" << endl;
+        }
         cout << endl;
         cout << "PartitionFinder's parameters:" << endl;
         cout << part_algo << endl;
@@ -5383,7 +5445,14 @@ void PartitionFinder::test_PartitionModel() {
 
     if (params->marginal_lh_aic) {
         //double score_bic = computeInformationScore(lhsum, dfsum, ssize, MTC_BIC);
-        inf_score_maic = getmAICforMergeScheme(gene_sets, model_names, dfsum, false);
+        // warm up the cache: this full-scheme call computes exactly the original-partition
+        // columns that the first merge round will reuse. The current blocks here are the
+        // original partitions (gene_sets is not populated yet at this point), so register their
+        // names as cacheable and let the call populate the cache (warmup_cache = true).
+        maic_current_blocks.clear();
+        for (int p = 0; p < in_tree->size(); p++)
+            maic_current_blocks.insert(in_tree->at(p)->aln->name);
+        inf_score_maic = getmAICforMergeScheme(gene_sets, model_names, dfsum, false, true);
         cout << "Full partition model mAIC score: " << inf_score_maic << " (Marginal LnL: " << lh_marginal << "  df:" << dfsum <<  ")" << endl;
     }
 
@@ -5626,6 +5695,11 @@ void PartitionFinder::test_PartitionModel() {
         }
         if (verbose_mode >= VB_MED) cout << "Agglomerative model selection: " << final_model_tree << endl;
     }
+
+    // merging finished, free the mAIC cache (and the cacheable-block set, so the final
+    // full-scheme call below runs uncached)
+    maic_subcol_cache.clear();
+    maic_current_blocks.clear();
 
 #ifdef _IQTREE_MPI
     if (num_processes > 1) {

--- a/main/phylotesting.cpp
+++ b/main/phylotesting.cpp
@@ -5384,7 +5384,11 @@ void PartitionFinder::test_PartitionModel() {
     if (params->partition_merge != MERGE_NONE) {
         // show the parameters for partition finder
         if (params->marginal_lh_aic) {
-            size_t mem_cache = (in_tree->size() + 1) * ssize * sizeof(double);
+            // cache columns are per-pattern; peak ~ (#blocks + 1) * (total #patterns) doubles
+            size_t total_nptn = 0;
+            for (int p = 0; p < in_tree->size(); p++)
+                total_nptn += in_tree->at(p)->aln->getNPattern();
+            size_t mem_cache = (in_tree->size() + 1) * total_nptn * sizeof(double);
             cout << "NOTE: mAIC marginal likelihood cache during merging requires up to "
                  << (mem_cache / 1048576) << " MB RAM (" << (mem_cache / 1073741824) << " GB)!" << endl;
         }

--- a/main/phylotesting.h
+++ b/main/phylotesting.h
@@ -485,6 +485,10 @@ private:
     double inf_score_maic;
     ModelPairSet sorted_pairs;
     SuperAlignment *cur_super_aln;
+
+    // marginal site-lh column cache, reused across merging
+    map<string, vector<double> > maic_subcol_cache;
+    set<string> maic_current_blocks; // names of the current scheme's blocks (the only cacheable ones)
     //vector<set<int> > cur_gene_sets;
 
     // retreive the answers from checkpoint
@@ -499,7 +503,13 @@ private:
      * merge : whether merge partitions with input gene sets
      * @return : mAIC score
      */
-    double getmAICforMergeScheme(vector<set<int> > gene_sets, StrVector model_names, int df, bool merge);
+    double getmAICforMergeScheme(vector<set<int> > gene_sets, StrVector model_names, int df, bool merge, bool warmup_cache = false);
+
+    /**
+     * evict from the cross-round mAIC column cache every entry whose data- or class-block
+     * overlaps the just-merged partition set (their blocks no longer recur)
+     */
+    void evictMergedFromCache(set<int> &merged_set);
 
     /**
      * get compatible partition pairs that improve mAIC

--- a/model/modelfactory.h
+++ b/model/modelfactory.h
@@ -301,6 +301,22 @@ public:
      */
     virtual double computeMarginalLh(bool remove_empty_seq) {return 0.0;}
 
+    /**
+     return the marginal log-likelihood for mAIC, computing (and caching) it on the first call.
+     @param remove_empty_seq whether remove empty sequences when partition model estimation
+     */
+    double getMarginalLh(bool remove_empty_seq) {
+        if (!computed_marginal_lh) {
+            marginal_lh = computeMarginalLh(remove_empty_seq);
+            computed_marginal_lh = true;
+        }
+        return marginal_lh;
+    }
+
+    /** cached marginal log-likelihood, valid only when computed_marginal_lh is true */
+    double marginal_lh = 0.0;
+    bool computed_marginal_lh = false;
+
 protected:
 
 	/**

--- a/model/partitionmodel.cpp
+++ b/model/partitionmodel.cpp
@@ -402,10 +402,33 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
         // get the site-log-likelihood the the partition under each tree and the corresponding model
         double *lh_array = new double [nparts*tree1_nsite];
 
+        // mAIC cache pre-pass (serial): fill cache hits, mark the rest to compute. A column is
+        // cacheable only if both its blocks are current-scheme blocks (maic_blocks); candidate
+        // merged blocks are computed but never stored.
+        string data_name = tree->at(part_indices[j])->aln->name;
+        vector<char> need_compute(nparts, 1);
+        vector<char> cacheable(nparts, 0);
+        if (maic_cache) {
+            bool data_ok = !maic_blocks || maic_blocks->count(data_name);
+            for (int k = 0; k < nparts; k++) {
+                if (!data_ok) break;
+                const string &class_name = tree->at(part_indices[k])->aln->name;
+                if (maic_blocks && !maic_blocks->count(class_name))
+                    continue; // candidate (merged) block: compute but never cache
+                cacheable[k] = 1;
+                auto it = maic_cache->find(data_name + '\x01' + class_name);
+                if (it != maic_cache->end()) {
+                    std::copy(it->second.begin(), it->second.end(), lh_array + (size_t)tree1_nsite*k);
+                    need_compute[k] = 0;
+                }
+            }
+        }
+
 #ifdef _OPENMP
 #pragma omp parallel for if(tree->num_threads > 1)
 #endif
         for (int k = 0; k < nparts ; k++) {
+            if (!need_compute[k]) continue; // mAIC cache hit: column already filled above
             PhyloTree *tree2 = tree->at(part_indices[k]);
 
             // get the intersection of tree1_aln and tree2.
@@ -617,6 +640,16 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 }
             }
             delete[] state_freq;
+        }
+
+        // mAIC cache store (serial): keep only freshly-computed cacheable columns
+        if (maic_cache) {
+            for (int k = 0; k < nparts; k++) {
+                if (need_compute[k] && cacheable[k]) {
+                    (*maic_cache)[data_name + '\x01' + tree->at(part_indices[k])->aln->name]
+                        .assign(lh_array + (size_t)tree1_nsite*k, lh_array + (size_t)tree1_nsite*(k+1));
+                }
+            }
         }
 
         // compute partition log-likelihood from sites

--- a/model/partitionmodel.cpp
+++ b/model/partitionmodel.cpp
@@ -457,7 +457,7 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 string inter_seqs_set (tree2_ntaxa, 0);
 
                 sub_tree2 = new PhyloTree();
-                if (tree2_seqs.size() != inter_seqs.size() || (!remove_empty_seq && tree2_seqs.size() < ntaxa)) {
+                //if (tree2_seqs.size() != inter_seqs.size() || (!remove_empty_seq && tree2_seqs.size() < ntaxa)) {
                     if (remove_empty_seq) {
                         for (int l = 0; l < tree2_seqs.size(); l++) {
                             if (inter_seqs.find(tree2_seqs[l]) != inter_seqs.end()) {
@@ -476,9 +476,9 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                     if (!tree2->getModel()->isReversible()) {
                         sub_tree2->nodeNum = 2 * sub_tree2->leafNum -2;
                     }
-                } else {
-                    sub_tree2->copyTree(tree2);
-                }
+               // } else {
+                //    sub_tree2->copyTree(tree2);
+                //}
 
                 if ((inter_seqs_id.size() == 2 && tree2->getModel()->isReversible()) ||
                     (inter_seqs_id.size() == 1 && !tree2->getModel()->isReversible())) {

--- a/model/partitionmodel.cpp
+++ b/model/partitionmodel.cpp
@@ -384,39 +384,45 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
     } else {
         tree->getTaxaName(taxa_names);
         for (int j = 0; j < nparts; j++) {
-            Alignment *part_aln = NULL;
-            part_aln = tree->at(part_indices[j])->aln->removeGappySeq(false);
+            Alignment *orig_aln = tree->at(part_indices[j])->aln;
+            Alignment *part_aln = orig_aln->removeGappySeq(false);
             t_seqs_vec_array[j] = part_aln->getSeqNames();
             t_seqs_set_array[j].insert(t_seqs_vec_array[j].begin(), t_seqs_vec_array[j].end());
+            // removeGappySeq returns a NEW alignment only when it drops gap-only seqs
+            // (otherwise it returns the original); free it just in that case to avoid a leak
+            if (part_aln != orig_aln)
+                delete part_aln;
         }
     }
 
     // compute the mixture-based log-likelihood
     double mix_lh = 0.0;
 
+    // collect the (j,k) columns still to compute into one flat list
+    vector<int> nptn_arr(nparts);
+    vector<IntVector> ptn_rep_arr(nparts);
+    vector<double*> lh_arrays(nparts, nullptr);
+    vector<vector<char> > col_cacheable(nparts);
+    vector<pair<int,int> > todo;                 // (j,k) columns to compute
     for (int j = 0; j < nparts; j++) {
         Alignment *tree1_aln = tree->at(part_indices[j])->aln;
         int tree1_nsite = tree1_aln->getNSite();
         int tree1_nptn  = tree1_aln->getNPattern();
-        StrVector tree1_seqs = t_seqs_vec_array[j];
+        nptn_arr[j] = tree1_nptn;
 
-        // the marginal site-lh depends only on the site's pattern.
-        // ptn_rep_site[p] is a representative site of pattern p, used to look up the sub-alignment's pattern.
-        IntVector ptn_rep_site(tree1_nptn, -1);
+        // representative site per pattern (marginal lh depends only on the pattern)
+        ptn_rep_arr[j].assign(tree1_nptn, -1);
         for (int l = 0; l < tree1_nsite; l++) {
             int pid = tree1_aln->getPatternID(l);
-            if (ptn_rep_site[pid] < 0) ptn_rep_site[pid] = l;
+            if (ptn_rep_arr[j][pid] < 0) ptn_rep_arr[j][pid] = l;
         }
 
-        // per-pattern log-likelihood of partition j under each tree and its model
-        double *lh_array = new double [nparts*tree1_nptn];
+        lh_arrays[j] = new double[(size_t)nparts * tree1_nptn];
+        col_cacheable[j].assign(nparts, 0);
 
-        // mAIC cache pre-pass (serial): fill cache hits, mark the rest to compute. A column is
-        // cacheable only if both its blocks are current-scheme blocks (maic_blocks); candidate
-        // merged blocks are computed but never stored.
-        string data_name = tree->at(part_indices[j])->aln->name;
+        // cache pre-pass: fill hits, mark the rest to compute (cacheable = both blocks current)
+        string data_name = tree1_aln->name;
         vector<char> need_compute(nparts, 1);
-        vector<char> cacheable(nparts, 0);
         if (maic_cache) {
             bool data_ok = !maic_blocks || maic_blocks->count(data_name);
             for (int k = 0; k < nparts; k++) {
@@ -424,20 +430,30 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 const string &class_name = tree->at(part_indices[k])->aln->name;
                 if (maic_blocks && !maic_blocks->count(class_name))
                     continue; // candidate (merged) block: compute but never cache
-                cacheable[k] = 1;
+                col_cacheable[j][k] = 1;
                 auto it = maic_cache->find(data_name + '\x01' + class_name);
                 if (it != maic_cache->end()) {
-                    std::copy(it->second.begin(), it->second.end(), lh_array + (size_t)tree1_nptn*k);
+                    std::copy(it->second.begin(), it->second.end(), lh_arrays[j] + (size_t)tree1_nptn*k);
                     need_compute[k] = 0;
                 }
             }
         }
+        for (int k = 0; k < nparts; k++)
+            if (need_compute[k]) todo.push_back(make_pair(j, k));
+    }
 
+    // compute all pending (j,k) columns in ONE parallel loop.
 #ifdef _OPENMP
-#pragma omp parallel for if(tree->num_threads > 1)
+#pragma omp parallel for schedule(dynamic) if(tree->num_threads > 1)
 #endif
-        for (int k = 0; k < nparts ; k++) {
-            if (!need_compute[k]) continue; // mAIC cache hit: column already filled above
+        for (int t = 0; t < (int)todo.size(); t++) {
+            int j = todo[t].first;
+            int k = todo[t].second;
+            Alignment *tree1_aln = tree->at(part_indices[j])->aln;
+            int tree1_nptn = nptn_arr[j];
+            IntVector &ptn_rep_site = ptn_rep_arr[j];
+            StrVector &tree1_seqs = t_seqs_vec_array[j];
+            double *lh_array = lh_arrays[j];
             PhyloTree *tree2 = tree->at(part_indices[k]);
 
             // get the intersection of tree1_aln and tree2.
@@ -651,41 +667,39 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
             delete[] state_freq;
         }
 
-        // mAIC cache store (serial): keep only freshly-computed cacheable columns
-        if (maic_cache) {
-            for (int k = 0; k < nparts; k++) {
-                if (need_compute[k] && cacheable[k]) {
-                    (*maic_cache)[data_name + '\x01' + tree->at(part_indices[k])->aln->name]
-                        .assign(lh_array + (size_t)tree1_nptn*k, lh_array + (size_t)tree1_nptn*(k+1));
-                }
+    // store freshly-computed cacheable columns
+    if (maic_cache) {
+        for (int t = 0; t < (int)todo.size(); t++) {
+            int j = todo[t].first, k = todo[t].second;
+            if (col_cacheable[j][k]) {
+                (*maic_cache)[tree->at(part_indices[j])->aln->name + '\x01' + tree->at(part_indices[k])->aln->name]
+                    .assign(lh_arrays[j] + (size_t)nptn_arr[j]*k, lh_arrays[j] + (size_t)nptn_arr[j]*(k+1));
             }
         }
+    }
 
-        // compute partition log-likelihood from patterns (each weighted by its site frequency)
+    // compute marginal likelihood over classes, per pattern, weighted by pattern frequency
+    for (int j = 0; j < nparts; j++) {
+        Alignment *tree1_aln = tree->at(part_indices[j])->aln;
+        int tree1_nptn = nptn_arr[j];
+        double *lh_array = lh_arrays[j];
         double mix_lh_partition = 0.0;
         for (int l = 0; l < tree1_nptn; l++) {
             double weighted_lh, max_lh, mix_lh_site;
             int ptn_freq = tree1_aln->at(l).frequency;
-
             for (int k = 0; k < nparts; k++) {
                 weighted_lh = log_weight_array[k]+lh_array[tree1_nptn*k+l];
-                if (k == 0) {
-                    max_lh = weighted_lh;
-                } else if (weighted_lh > max_lh) {
-                    max_lh = weighted_lh;
-                }
+                if (k == 0) max_lh = weighted_lh;
+                else if (weighted_lh > max_lh) max_lh = weighted_lh;
             }
-
             double mix_lh_site_original = 0.0;
-            for (int k = 0; k < nparts; k++) {
+            for (int k = 0; k < nparts; k++)
                 mix_lh_site_original += exp(log_weight_array[k]+lh_array[tree1_nptn*k+l]-max_lh);
-            }
             mix_lh_site = max_lh + log(mix_lh_site_original);
             mix_lh_partition += mix_lh_site * ptn_freq;
         }
         mix_lh += mix_lh_partition;
-
-        delete[] lh_array; //release array memery
+        delete[] lh_arrays[j];
     }
     return mix_lh;
 }

--- a/model/partitionmodel.cpp
+++ b/model/partitionmodel.cpp
@@ -486,13 +486,18 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
 
             if (inter_seqs_id.size() > 1 ||
                 (inter_seqs_id.size() == 1 && !tree2->getModel()->isReversible())) {
-                // subset tree1_aln
-                Alignment *sub_tree1_aln = nullptr;
-                if (tree1_seqs.size() != inter_seqs.size() || (!remove_empty_seq && tree1_seqs.size() < ntaxa)) {
-                    sub_tree1_aln = tree1_aln->extractSubAlignment(inter_seqs_id, 0, 0, nullptr, false);
-                } else {
-                    sub_tree1_aln = tree1_aln;
-                }
+                // the gappy-taxon branch below mutates sub_tree1_aln in place, so we must NOT
+                // alias tree1_aln when it runs (that would corrupt the shared partition alignment).
+                bool gappy_case = (inter_seqs_id.size() == 2 && tree2->getModel()->isReversible()) ||
+                                  (inter_seqs_id.size() == 1 && !tree2->getModel()->isReversible());
+                bool own_sub1_aln = tree1_seqs.size() != inter_seqs.size()
+                                    || (!remove_empty_seq && tree1_seqs.size() < ntaxa)
+                                    || gappy_case;
+
+                // subset tree1_aln (own a private copy unless it is exactly tree1_aln and untouched)
+                Alignment *sub_tree1_aln = own_sub1_aln
+                    ? tree1_aln->extractSubAlignment(inter_seqs_id, 0, 0, nullptr, false)
+                    : tree1_aln;
 
                 // subset tree2
                 PhyloTree *sub_tree2 = nullptr;
@@ -528,8 +533,7 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 //    sub_tree2->copyTree(tree2);
                 //}
 
-                if ((inter_seqs_id.size() == 2 && tree2->getModel()->isReversible()) ||
-                    (inter_seqs_id.size() == 1 && !tree2->getModel()->isReversible())) {
+                if (gappy_case) {
                     // too few taxa for likelihood kernel; add a gappy taxon with all-unknown states
                     string gappy_seq = "gappy_seq";
                     sub_tree1_aln->addSeqName(gappy_seq);
@@ -620,7 +624,7 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 }
 
                 //release memory
-                if (tree1_seqs.size() != inter_seqs.size() || (!remove_empty_seq && tree1_seqs.size() < ntaxa)) {
+                if (own_sub1_aln) {
                     delete sub_tree1_aln;
                 }
                 sub_tree2->setModelFactory(nullptr);

--- a/model/partitionmodel.cpp
+++ b/model/partitionmodel.cpp
@@ -397,10 +397,19 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
     for (int j = 0; j < nparts; j++) {
         Alignment *tree1_aln = tree->at(part_indices[j])->aln;
         int tree1_nsite = tree1_aln->getNSite();
+        int tree1_nptn  = tree1_aln->getNPattern();
         StrVector tree1_seqs = t_seqs_vec_array[j];
 
-        // get the site-log-likelihood the the partition under each tree and the corresponding model
-        double *lh_array = new double [nparts*tree1_nsite];
+        // the marginal site-lh depends only on the site's pattern.
+        // ptn_rep_site[p] is a representative site of pattern p, used to look up the sub-alignment's pattern.
+        IntVector ptn_rep_site(tree1_nptn, -1);
+        for (int l = 0; l < tree1_nsite; l++) {
+            int pid = tree1_aln->getPatternID(l);
+            if (ptn_rep_site[pid] < 0) ptn_rep_site[pid] = l;
+        }
+
+        // per-pattern log-likelihood of partition j under each tree and its model
+        double *lh_array = new double [nparts*tree1_nptn];
 
         // mAIC cache pre-pass (serial): fill cache hits, mark the rest to compute. A column is
         // cacheable only if both its blocks are current-scheme blocks (maic_blocks); candidate
@@ -418,7 +427,7 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 cacheable[k] = 1;
                 auto it = maic_cache->find(data_name + '\x01' + class_name);
                 if (it != maic_cache->end()) {
-                    std::copy(it->second.begin(), it->second.end(), lh_array + (size_t)tree1_nsite*k);
+                    std::copy(it->second.begin(), it->second.end(), lh_array + (size_t)tree1_nptn*k);
                     need_compute[k] = 0;
                 }
             }
@@ -554,10 +563,10 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                 //compute site log-likelihood
                 if (tree1_seqs.size() != inter_seqs.size()) {
                     //for sequences only appears in tree1, calculate the state frequencies based on the model in tree2
-                    for (int l = 0; l < tree1_nsite; l++) {
-                        int ptn_id = sub_tree1_aln->getPatternID(l);
+                    for (int l = 0; l < tree1_nptn; l++) {
+                        int ptn_id = sub_tree1_aln->getPatternID(ptn_rep_site[l]);
                         double site_lh = ptn_lh_array[ptn_id];
-                        Pattern p = tree1_aln->at(tree1_aln->getPatternID(l));
+                        Pattern p = tree1_aln->at(l);
 
                         for (int missing_id: missing_seqs_id) {
                             int char_id = p[missing_id];
@@ -585,12 +594,12 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                                 }
                             }
                         }
-                        lh_array[tree1_nsite * k + l] = site_lh;
+                        lh_array[tree1_nptn * k + l] = site_lh;
                     }
                 } else {
-                    for (int l = 0; l < tree1_nsite; l++) {
-                        int ptn_id = sub_tree1_aln->getPatternID(l);
-                        lh_array[tree1_nsite * k + l] = ptn_lh_array[ptn_id];
+                    for (int l = 0; l < tree1_nptn; l++) {
+                        int ptn_id = sub_tree1_aln->getPatternID(ptn_rep_site[l]);
+                        lh_array[tree1_nptn * k + l] = ptn_lh_array[ptn_id];
                     }
                 }
 
@@ -605,9 +614,9 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
             } else {
                 // case when the intersection of taxon sets is 0 or 1 (reversible model)
                 // all taxa use state frequencies only
-                for (int l = 0; l < tree1_nsite; l++) {
+                for (int l = 0; l < tree1_nptn; l++) {
                     double site_lh = 0.0;
-                    Pattern p = tree1_aln->at(tree1_aln->getPatternID(l));
+                    Pattern p = tree1_aln->at(l);
 
                     for (string seq_name : tree1_seqs) {
                         int missing_id = tree1_aln->getSeqID(seq_name);
@@ -636,7 +645,7 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
                             }
                         }
                     }
-                    lh_array[tree1_nsite * k + l] = site_lh;
+                    lh_array[tree1_nptn * k + l] = site_lh;
                 }
             }
             delete[] state_freq;
@@ -647,18 +656,19 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
             for (int k = 0; k < nparts; k++) {
                 if (need_compute[k] && cacheable[k]) {
                     (*maic_cache)[data_name + '\x01' + tree->at(part_indices[k])->aln->name]
-                        .assign(lh_array + (size_t)tree1_nsite*k, lh_array + (size_t)tree1_nsite*(k+1));
+                        .assign(lh_array + (size_t)tree1_nptn*k, lh_array + (size_t)tree1_nptn*(k+1));
                 }
             }
         }
 
-        // compute partition log-likelihood from sites
+        // compute partition log-likelihood from patterns (each weighted by its site frequency)
         double mix_lh_partition = 0.0;
-        for (int l = 0; l < tree1_nsite; l++) {
+        for (int l = 0; l < tree1_nptn; l++) {
             double weighted_lh, max_lh, mix_lh_site;
+            int ptn_freq = tree1_aln->at(l).frequency;
 
             for (int k = 0; k < nparts; k++) {
-                weighted_lh = log_weight_array[k]+lh_array[tree1_nsite*k+l];
+                weighted_lh = log_weight_array[k]+lh_array[tree1_nptn*k+l];
                 if (k == 0) {
                     max_lh = weighted_lh;
                 } else if (weighted_lh > max_lh) {
@@ -668,10 +678,10 @@ double PartitionModel::computeMarginalLhForPartitions(vector<int> &part_indices,
 
             double mix_lh_site_original = 0.0;
             for (int k = 0; k < nparts; k++) {
-                mix_lh_site_original += exp(log_weight_array[k]+lh_array[tree1_nsite*k+l]-max_lh);
+                mix_lh_site_original += exp(log_weight_array[k]+lh_array[tree1_nptn*k+l]-max_lh);
             }
             mix_lh_site = max_lh + log(mix_lh_site_original);
-            mix_lh_partition += mix_lh_site;
+            mix_lh_partition += mix_lh_site * ptn_freq;
         }
         mix_lh += mix_lh_partition;
 

--- a/model/partitionmodel.h
+++ b/model/partitionmodel.h
@@ -144,6 +144,13 @@ public:
      */
     double computeMarginalLhForPartitions(vector<int> &part_indices, bool remove_empty_seq);
 
+    // mAIC merge-phase cache (all set by PartitionFinder; nullptr = caching off, original path).
+    // maic_cache : per-(data block, class block) site-lh columns, keyed "data\x01class".
+    // maic_blocks: only columns whose both blocks are in here (current-scheme blocks) are cached;
+    //              candidate merged blocks aren't, so their columns are computed but not stored.
+    map<string, vector<double> > *maic_cache = nullptr;
+    set<string> *maic_blocks = nullptr;
+
     /**
      rescale the state frequencies
      @param sum_one TRUE to make frequencies sum to 1, FALSE to make last entry equal to 1

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -4549,10 +4549,12 @@ void parseArg(int argc, char *argv[], Params &params) {
 			}
 			if (strcmp(argv[cnt], "-AIC") == 0) {
 				params.model_test_criterion = MTC_AIC;
+				params.merit_specified = true;
 				continue;
 			}
 			if (strcmp(argv[cnt], "-AICc") == 0 || strcmp(argv[cnt], "-AICC") == 0) {
 				params.model_test_criterion = MTC_AICC;
+				params.merit_specified = true;
 				continue;
 			}
 			if (strcmp(argv[cnt], "-merit") == 0 || strcmp(argv[cnt], "--merit") == 0) {
@@ -4561,10 +4563,13 @@ void parseArg(int argc, char *argv[], Params &params) {
 					throw "Use -merit AIC|AICC|BIC";
                 if (strcmp(argv[cnt], "AIC") == 0) {
                     params.model_test_criterion = MTC_AIC;
+                    params.marginal_lh_aic = false;
                 } else if (strcmp(argv[cnt], "AICc") == 0 || strcmp(argv[cnt], "AICC") == 0) {
                     params.model_test_criterion = MTC_AICC;
+                    params.marginal_lh_aic = false;
                 } else if (strcmp(argv[cnt], "BIC") == 0) {
                     params.model_test_criterion = MTC_BIC;
+                    params.marginal_lh_aic = false;
                 } else if (strcmp(argv[cnt], "mAIC") == 0) {
                     params.marginal_lh_aic = true;
                     params.model_test_criterion = MTC_AIC;
@@ -4572,8 +4577,9 @@ void parseArg(int argc, char *argv[], Params &params) {
                     params.marginal_lh_aic = true;
                     params.model_test_criterion = MTC_BIC;
                 } else {
-                    throw "Use -merit AIC|AICC|BIC";
+                    throw "Use -merit AIC|AICC|BIC|mAIC|mAIC+BIC";
                 }
+                params.merit_specified = true;
 				continue;
 			}
 			if (strcmp(argv[cnt], "-ms") == 0) {
@@ -5617,6 +5623,12 @@ void parseArg(int argc, char *argv[], Params &params) {
         if (params.partition_merge == MERGE_NONE)
             params.partition_merge = MERGE_RCLUSTERF;
 
+    // merging defaults to mAIC (i.e. -merit mAIC), unless the user asked for a particular merit
+    if (params.partition_merge != MERGE_NONE && !params.merit_specified) {
+        params.marginal_lh_aic = true;
+        params.model_test_criterion = MTC_AIC;
+    }
+
     // Set MrBayes Block Output if -mset mrbayes
     if (params.model_set == "mrbayes")
         params.mr_bayes_output = true;
@@ -5915,7 +5927,11 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "                       (e.g. -mrate E,I,G,I+G,R is used for -m MF)" << endl
     << "  --cmin NUM           Min categories for FreeRate model [+R] (default: 2)" << endl
     << "  --cmax NUM           Max categories for FreeRate model [+R] (default: 10)" << endl
-    << "  --merit AIC|AICc|BIC  Akaike|Bayesian information criterion (default: BIC)" << endl
+    << "  --merit AIC|AICc|BIC|mAIC|mAIC+BIC" << endl
+    << "                       Akaike|Bayesian information criterion (default: BIC," << endl
+    << "                       or mAIC when merging partitions). mAIC uses the" << endl
+    << "                       marginal AIC to merge partitions; mAIC+BIC merges by" << endl
+    << "                       mAIC but selects individual models by BIC" << endl
 //            << "  -msep                Perform model selection and then rate selection" << endl
     << "  --mtree              Perform full tree search for every model" << endl
     << "  --madd STR,...       List of mixture models to consider" << endl
@@ -7156,7 +7172,8 @@ void Params::setDefault() {
     merge_models = "1";
     merge_rates = "1";
     partfinder_log_rate = true;
-    
+    marginal_lh_aic = false; // turned on by default for +MERGE, see parseArg
+
     sequence_type = nullptr;
     aln_output = nullptr;
     aln_site_list = nullptr;
@@ -7403,6 +7420,7 @@ void Params::setDefault() {
     num_threads_orig = 0;
     openmp_by_model = false;
     model_test_criterion = MTC_BIC;
+    merit_specified = false;
     //    model_test_stop_rule = MTC_ALL;
     model_test_sample_size = 0;
     root_state = nullptr;

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -4549,18 +4549,18 @@ void parseArg(int argc, char *argv[], Params &params) {
 			}
 			if (strcmp(argv[cnt], "-AIC") == 0) {
 				params.model_test_criterion = MTC_AIC;
-				params.merit_specified = true;
+				params.marginal_lh_aic = false;
 				continue;
 			}
 			if (strcmp(argv[cnt], "-AICc") == 0 || strcmp(argv[cnt], "-AICC") == 0) {
 				params.model_test_criterion = MTC_AICC;
-				params.merit_specified = true;
+				params.marginal_lh_aic = false;
 				continue;
 			}
 			if (strcmp(argv[cnt], "-merit") == 0 || strcmp(argv[cnt], "--merit") == 0) {
                 cnt++;
 				if (cnt >= argc)
-					throw "Use -merit AIC|AICC|BIC";
+					throw "Use -merit AIC|AICC|BIC|mAIC";
                 if (strcmp(argv[cnt], "AIC") == 0) {
                     params.model_test_criterion = MTC_AIC;
                     params.marginal_lh_aic = false;
@@ -4579,7 +4579,6 @@ void parseArg(int argc, char *argv[], Params &params) {
                 } else {
                     throw "Use -merit AIC|AICC|BIC|mAIC";
                 }
-                params.merit_specified = true;
 				continue;
 			}
 			if (strcmp(argv[cnt], "-ms") == 0) {
@@ -5623,12 +5622,6 @@ void parseArg(int argc, char *argv[], Params &params) {
         if (params.partition_merge == MERGE_NONE)
             params.partition_merge = MERGE_RCLUSTERF;
 
-    // merging defaults to mAIC (i.e. -merit mAIC), unless the user asked for a particular merit
-    if (params.partition_merge != MERGE_NONE && !params.merit_specified) {
-        params.marginal_lh_aic = true;
-        params.model_test_criterion = MTC_AIC;
-    }
-
     // Set MrBayes Block Output if -mset mrbayes
     if (params.model_set == "mrbayes")
         params.mr_bayes_output = true;
@@ -5928,9 +5921,8 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "  --cmin NUM           Min categories for FreeRate model [+R] (default: 2)" << endl
     << "  --cmax NUM           Max categories for FreeRate model [+R] (default: 10)" << endl
     << "  --merit AIC|AICc|BIC|mAIC" << endl
-    << "                       Akaike|Bayesian information criterion (default: BIC," << endl
-    << "                       or mAIC when merging partitions). mAIC uses the" << endl
-    << "                       marginal AIC to merge partitions" << endl
+    << "                       Akaike|Bayesian information criterion (default: BIC)" << endl
+    << "                       mAIC uses the marginal AIC to merge partitions in partition models" << endl
 //            << "  -msep                Perform model selection and then rate selection" << endl
     << "  --mtree              Perform full tree search for every model" << endl
     << "  --madd STR,...       List of mixture models to consider" << endl
@@ -7171,7 +7163,7 @@ void Params::setDefault() {
     merge_models = "1";
     merge_rates = "1";
     partfinder_log_rate = true;
-    marginal_lh_aic = false; // turned on by default for +MERGE, see parseArg
+    marginal_lh_aic = false;
 
     sequence_type = nullptr;
     aln_output = nullptr;
@@ -7419,7 +7411,6 @@ void Params::setDefault() {
     num_threads_orig = 0;
     openmp_by_model = false;
     model_test_criterion = MTC_BIC;
-    merit_specified = false;
     //    model_test_stop_rule = MTC_ALL;
     model_test_sample_size = 0;
     root_state = nullptr;

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -4577,7 +4577,7 @@ void parseArg(int argc, char *argv[], Params &params) {
                     params.marginal_lh_aic = true;
                     params.model_test_criterion = MTC_BIC;
                 } else {
-                    throw "Use -merit AIC|AICC|BIC|mAIC|mAIC+BIC";
+                    throw "Use -merit AIC|AICC|BIC|mAIC";
                 }
                 params.merit_specified = true;
 				continue;
@@ -5927,11 +5927,10 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "                       (e.g. -mrate E,I,G,I+G,R is used for -m MF)" << endl
     << "  --cmin NUM           Min categories for FreeRate model [+R] (default: 2)" << endl
     << "  --cmax NUM           Max categories for FreeRate model [+R] (default: 10)" << endl
-    << "  --merit AIC|AICc|BIC|mAIC|mAIC+BIC" << endl
+    << "  --merit AIC|AICc|BIC|mAIC" << endl
     << "                       Akaike|Bayesian information criterion (default: BIC," << endl
     << "                       or mAIC when merging partitions). mAIC uses the" << endl
-    << "                       marginal AIC to merge partitions; mAIC+BIC merges by" << endl
-    << "                       mAIC but selects individual models by BIC" << endl
+    << "                       marginal AIC to merge partitions" << endl
 //            << "  -msep                Perform model selection and then rate selection" << endl
     << "  --mtree              Perform full tree search for every model" << endl
     << "  --madd STR,...       List of mixture models to consider" << endl

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -2388,6 +2388,10 @@ public:
     /** either MTC_AIC, MTC_AICc, MTC_BIC */
     ModelTestCriterion model_test_criterion;
 
+    /** true if the user selected a merit explicitly (-merit/-AIC/-AICc), which then
+        overrides the mAIC merging criterion that +MERGE turns on by default */
+    bool merit_specified;
+
     /** either MTC_AIC, MTC_AICc, MTC_BIC, or MTC_ALL to stop +R increasing categories */
 //    ModelTestCriterion model_test_stop_rule;
 

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -2388,10 +2388,6 @@ public:
     /** either MTC_AIC, MTC_AICc, MTC_BIC */
     ModelTestCriterion model_test_criterion;
 
-    /** true if the user selected a merit explicitly (-merit/-AIC/-AICc), which then
-        overrides the mAIC merging criterion that +MERGE turns on by default */
-    bool merit_specified;
-
     /** either MTC_AIC, MTC_AICc, MTC_BIC, or MTC_ALL to stop +R increasing categories */
 //    ModelTestCriterion model_test_stop_rule;
 


### PR DESCRIPTION
speed up PartitionFinder-mAIC by:
- remove copyTree()
- change site-lh to pattern-lh
- cache the lh vector of partition A and model B in the partitioning scheme and reuse (the most important for runtime)
- flat the two-layer loop (j for partitions, k for models) to one loop (for (j,k) pair)

move the final mAIC computation to before final time stamp.

set mAIC as default option for PartitionFinder.