### PR TITLE
Fix setRootNode() assertion when the -o outgroup is absent from a partition tree or a quartet tree (#203, #89)

### DIFF
--- a/test_scripts/test_data/expect_ans.txt
+++ b/test_scripts/test_data/expect_ans.txt
@@ -6,6 +6,8 @@ turtle.mix.iqtree	Log-likelihood of the tree	-5342.1012	1
 turtle.mix.jc.link.iqtree	Log-likelihood of the tree	-5827.4822	1
 turtle.mix.link.iqtree	Log-likelihood of the tree	-5625.6391	1
 turtle.mixfinder.iqtree	Log-likelihood of the tree	-5332.2489	1
+turtle.nex.outgroup.iqtree	Log-likelihood of the tree	-5352.2653	1
+turtle.lmap.outgroup.iqtree	Log-likelihood of the tree	-5377.9500	1
 turtle.nex.constr.iqtree	Log-likelihood of the tree	-5360.0758	1
 turtle.nex.constr2.iqtree	Log-likelihood of the tree	-5360.0758	1
 turtle.nex.iqtree	Log-likelihood of the tree	-5360.0759	1

--- a/test_scripts/test_iqtree.ps1
+++ b/test_scripts/test_iqtree.ps1
@@ -96,6 +96,10 @@ Measure-IQTree "$IQTreeBin -s $WD/turtle.fa -p $WD/turtle.nex -g $WD/turtle.cons
 
 Measure-IQTree "$IQTreeBin -s $WD/turtle.fa -m `"MIX+MF`" --prefix $OutDir/turtle.mixfinder -T 1 -seed $SEED"
 
+# outgroup absent from some partitions / from the quartet trees (issues #203, #89)
+Measure-IQTree "$IQTreeBin -s $WD/turtle.fa -p $WD/turtle.nex -o phrynops -m GTR+G --prefix $OutDir/turtle.nex.outgroup -T 1 -seed $SEED"
+Measure-IQTree "$IQTreeBin -s $WD/turtle.fa -lmap 100 -o phrynops -m GTR+G --prefix $OutDir/turtle.lmap.outgroup -T 1 -seed $SEED"
+
 ## amino acid test cases
 Write-Host "Running amino acid test cases..."
 

--- a/test_scripts/test_iqtree.sh
+++ b/test_scripts/test_iqtree.sh
@@ -86,6 +86,12 @@ run_timed ${IQTREE_BIN} -s ${WD}/turtle.fa -p ${WD}/turtle.nex -g ${WD}/turtle.c
 
 run_timed ${IQTREE_BIN} -s ${WD}/turtle.fa -m "MIX+MF" --prefix ${OUT_DIR}/turtle.mixfinder -T 1 -seed $SEED
 
+# outgroup absent from some partitions / from the quartet trees (issues #203, #89)
+
+run_timed ${IQTREE_BIN} -s ${WD}/turtle.fa -p ${WD}/turtle.nex -o phrynops -m GTR+G --prefix ${OUT_DIR}/turtle.nex.outgroup -T 1 -seed $SEED
+
+run_timed ${IQTREE_BIN} -s ${WD}/turtle.fa -lmap 100 -o phrynops -m GTR+G --prefix ${OUT_DIR}/turtle.lmap.outgroup -T 1 -seed $SEED
+
 
 ## amino acid test cases
 echo "Running amino acid test cases..."

--- a/tree/phylotree.cpp
+++ b/tree/phylotree.cpp
@@ -480,24 +480,34 @@ void PhyloTree::setRootNode(const char *my_root, bool multi_taxa) {
         return;
     }
 
-    if (strchr(my_root, ',') == nullptr) {
-        string root_name = my_root;
-        root = findNodeName(root_name);
+    // my_root is one taxon or a comma-separated list of taxa.
+    // An outgroup taxon may legitimately be absent from this tree: the tree of a
+    // partition in which the taxon has no data, or a quartet tree of likelihood
+    // mapping (issues #203, #89). Such taxa are skipped; if none is left, the
+    // tree is rooted at its first taxon, as when no outgroup was given.
+    StrVector taxa;
+    convert_string_vec(my_root, taxa);
+    unordered_set<string> taxa_set;
+    Node *new_root = nullptr;
+    for (auto it = taxa.begin(); it != taxa.end(); it++) {
+        Node *node = findNodeName(*it);
+        if (!node) {
+            continue;
+        }
+        if (!new_root) {
+            new_root = node;
+        }
+        taxa_set.insert(*it);
+    }
+    if (!new_root) {
+        root = findNodeName(aln->getSeqName(0));
         ASSERT(root);
         return;
     }
-
-    // my_root is a list of taxa
-    StrVector taxa;
-    convert_string_vec(my_root, taxa);
-    root = findNodeName(taxa[0]);
-    ASSERT(root);
-    if (!multi_taxa) {
+    root = new_root;
+    if (!multi_taxa || taxa_set.size() < 2) {
         return;
     }
-    unordered_set<string> taxa_set;
-    for (auto it = taxa.begin(); it != taxa.end(); it++)
-        taxa_set.insert(*it);
     pair<Node*,Neighbor*> res = {nullptr, nullptr};
     findNodeNames(taxa_set, res, root->neighbors[0]->node, root);
     if (res.first)


### PR DESCRIPTION
Fixes #203. Also fixes #89, which is the same assertion on the `-lmap` path.

**Cause.** With `-o`, `PhyloTree::setRootNode()` (`tree/phylotree.cpp`) is called not only on the supertree but also on every per-partition `PhyloTree` of a `PhyloSuperTree` (from `saveCheckpoint()` → `getTreeString()` during the fast ML tree search of ModelFinder, and from `PartitionModel::computeMarginalLhForPartitions()` when the `.iqtree` report is written) and on the 4-taxon quartet trees of likelihood mapping (`readTreeStringSeqName()`). A partition tree does not contain a taxon that has no data in that partition, and a quartet tree contains only its four taxa, so `findNodeName()` returns null and `ASSERT(root)` aborts with

```
ERROR: phylotree.cpp:486: virtual void PhyloTree::setRootNode(const char*, bool): Assertion `root' failed.
```

This is exactly the situation in #203 (14 taxa, two partitions, the outgroup among the 8 taxa without LSU data; the crash comes right after "Time for fast ML tree search"), in #89 (`-lmap` with `-o`), and very likely in #135 and #102, which show the same assertion on partitioned/concatenated data with `-o`.

**Fix.** `setRootNode()` now skips outgroup taxa that are not leaves of the tree at hand; if none is left, the tree is rooted at its first taxon, exactly as when no `-o` is given. For a multi-taxon outgroup the "branch separating outgroup" search uses only the taxa present in the tree. The outgroup is still validated against the alignment (`IQTree::computeInitialTree()`, `runPhyloAnalysis()`), so a misspelled `-o` still stops with "Specified outgroup taxon ... not found"; the change only affects trees that legitimately lack the taxon, where the root choice has no effect on the likelihood (the trees are unrooted; the root only fixes the traversal order). Runs without `-o`, and runs with `-o` where the outgroup has data in every partition, are byte-identical before and after.

**Test.** `test_scripts/test_iqtree.sh` (and `test_iqtree.ps1`) get two commands on the existing turtle data, where `phrynops` has no data in the fourth partition: `-p turtle.nex -o phrynops` and `-lmap 100 -o phrynops`, both `-m GTR+G -T 1 -seed 73073`. Both abort on `main` and complete with the patch; their log-likelihoods are added to `test_data/expect_ans.txt` for `verify_results.sh`.

**Run.** Built with cmake/gcc 13.3 on Linux x86-64 as in CI (without `-DIQTREE_FLAGS=static`). `test_scripts/test_iqtree.sh` + `verify_results.sh`: 21 of 21 existing checks pass before and after, and the two new checks pass after (23 of 23; both commands abort before). A synthetic 14-taxon reproduction of #203 (`-p`, `-q`, `-Q`, with `-m MFP` and `-m GTR+G`) and of #89 (`-lmap` with one and with two outgroup taxa) aborts before and completes after.

Found while working through open issues in Mytochondria, a volunteer project that verifies fixes for the software behind published results (methods and harnesses: https://github.com/cindykrafft/mytochondria/tree/main/audits/iqtree)

---
_Generated by [Claude Code](https://claude.ai/code)_