### PR TITLE
Error out when a partition model is combined with -fs/-ft instead of silently ignoring them

### DIFF
--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -5631,8 +5631,24 @@ void parseArg(int argc, char *argv[], Params &params) {
     // terminate if using AliSim with -ft or -fs site-specific model (ModelSet)
     // computeTransMatix has not yet implemented for ModelSet
     if (params.alisim_active && (params.tree_freq_file || params.site_freq_file))
-        outError("Sorry! `-ft` (--site-freq) and `-fs` (--tree-freq) options are not fully supported in AliSim. However, AliSim can estimate posterior mean frequencies from the alignment. Please try again without `-ft` and `-fs` options!");
+        outError("Sorry! `-ft` (--tree-freq) and `-fs` (--site-freq) options are not fully supported in AliSim. However, AliSim can estimate posterior mean frequencies from the alignment. Please try again without `-ft` and `-fs` options!");
     
+    // Site-frequency models are read only on the non-partition code path. In
+    // runPhyloAnalysis() the call to Alignment::readSiteStateFreq() sits in the `else`
+    // branch of `if (params.partition_file)`, so combining a partition model with -fs or
+    // -ft silently DISCARDED the frequencies: the run completed, reported a likelihood,
+    // and printed no warning, while scoring under the plain model. Fail explicitly instead.
+    if (params.partition_file && params.site_freq_file)
+        outError("`-fs` (--site-freq) cannot be combined with a partition model (-p/-q/-Q/-S)."
+                 " Site frequencies are only applied to a single-partition alignment, and were"
+                 " previously ignored without warning. Run -fs without a partition file, or drop"
+                 " -fs and specify per-partition models in the partition file.");
+
+    if (params.partition_file && params.tree_freq_file)
+        outError("`-ft` (--tree-freq) cannot be combined with a partition model (-p/-q/-Q/-S)."
+                 " The site-frequency model is only estimated for a single-partition alignment,"
+                 " and was previously ignored without warning.");
+
     // Users have to specify a random seed to run AliSim
     if (params.alisim_active && !params.seed_specified)
         outError("To make the simulation reproducible, please specify a random seed via `-seed <NUM>`");


### PR DESCRIPTION
## The bug

Site-frequency models are read only on the non-partition code path. In `runPhyloAnalysis()` the call to `Alignment::readSiteStateFreq()` sits in the `else` branch of `if (params.partition_file)`, so combining a partition model with `-fs` or `-ft` **silently discards** the frequencies. The run completes, reports a likelihood, and prints no warning — while scoring under the plain partition model.

## Reproducing it

33-taxon alignment, 4-way partition, IQ-TREE 3.1.3:

```
-m LG+G4 -fs profiles.sitefreq       lnL = -2612.0434
-p parts.nex                          lnL = -2828.8242
-p parts.nex -fs profiles.sitefreq    lnL = -2828.8242   <- identical to -p alone
```

The third run reproduces the second's likelihood to the digit, and its log contains no `Reading site-specific state frequency file` line, so the `-fs` file was never opened. Here the profiles were worth 216 log units and a user has no way to notice they were dropped.

This is easy to hit. Anyone combining a PMSF-style site-frequency file with a partitioned analysis gets a plausible number computed under a different model from the one they asked for.

## The change

An explicit check beside the existing AliSim/`-fs` validation in `parseArg()`, following that function's `outError()` convention. 17 lines, no behaviour change to any working invocation.

I deliberately did **not** try to make the two compose. Supporting per-site frequencies inside a partition model is a feature with design questions attached (per-partition or global file? how do site indices map across partitions?), and it belongs in a separate discussion. This PR only stops the silent data loss.

## Verification

Built both this branch and stock at the same commit (`6c1b7ec`) and ran all three cases:

| invocation | stock | patched |
|---|---|---|
| `-fs` alone | exit 0, `-2612.0434` | exit 0, `-2612.0434` |
| `-p` alone | exit 0, `-2828.8242` | exit 0, `-2828.8242` |
| `-p` + `-fs` | exit 0, `-2828.8242` (silent) | **exit 2, explicit error** |

Both working invocations are unchanged. Only the combination now stops, with a message naming the cause and both ways forward.

## Also included

The adjacent AliSim error message has its long option names swapped — it reads ``-ft` (--site-freq) and `-fs` (--tree-freq)``, but the parser at `tools.cpp:3173` and `:3183` has `-fs` = `--site-freq` and `-ft` = `--tree-freq`. One-line correction in the same function.

Happy to split that out if you would rather keep the PR to one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
